### PR TITLE
Adding internal url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,6 +63,9 @@ ENV NODE_ENV production
 # Disable telemetry during runtime.
 ENV NEXT_TELEMETRY_DISABLED 1
 
+# adding internal url. https://github.com/sinamics/ztnet/issues/105
+ENV NEXTAUTH_URL_INTERNAL http://localhost:3000
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 RUN apt update && apt install -y curl sudo postgresql-client && apt clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
New environment variable, `NEXTAUTH_URL_INTERNAL`, to the application's Docker configuration. This variable is specifically aimed at improving server-side fetch operations for authentication by allowing the server to make calls to itself without routing through the public IP.


refrence #105 