### PR TITLE
Improved planet creation

### DIFF
--- a/src/pages/api/mkworld/config.ts
+++ b/src/pages/api/mkworld/config.ts
@@ -134,13 +134,13 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 												 *
 												 */
 												// Extract the port number from the endpoint string
-												const portNumber = parseInt(
-													plEndpoints.split("/").pop() || "",
-													10,
-												);
-
+												const portNumbers = plEndpoints
+													.split(",")
+													.map((endpoint) =>
+														parseInt(endpoint.split("/").pop() || "", 10),
+													);
 												try {
-													await updateLocalConf(portNumber);
+													await updateLocalConf(portNumbers);
 												} catch (_error) {
 													res.status(400).json({
 														error: "Error parsing mkworld.config.json",

--- a/src/server/api/routers/adminRoute.ts
+++ b/src/server/api/routers/adminRoute.ts
@@ -747,30 +747,13 @@ export const adminRouter = createTRPCRouter({
 							"If plRecommend is false, both plID and plBirth need to be provided.",
 						path: ["plID", "plBirth"], // Path of the fields the error refers to
 					},
-				)
-				.refine(
-					(data) => {
-						if (
-							data.plID === 149604618 || // official world in production ZeroTier Cloud
-							data.plID === 227883110 || // reserved world for future
-							data.plBirth === 1567191349589
-						) {
-							return false;
-						}
-						if (!data.plRecommend && data.plBirth <= 1567191349589) {
-							return false;
-						}
-						return true;
-					},
-					{
-						message:
-							"Invalid Planet ID / Birth values provided. Consider using recommended values.",
-						path: ["plID", "plBirth"],
-					},
 				),
 		)
 
 		.mutation(async ({ ctx, input }) => {
+			// data.plID 149604618 // official world in production ZeroTier Cloud
+			// data.plID  227883110  // reserved world for future
+			// data.plBirth 1567191349589
 			try {
 				const zerotierOneDir = "/var/lib/zerotier-one";
 				const mkworldDir = `${zerotierOneDir}/zt-mkworld`;

--- a/src/server/api/routers/adminRoute.ts
+++ b/src/server/api/routers/adminRoute.ts
@@ -828,12 +828,12 @@ export const adminRouter = createTRPCRouter({
 				const portNumbers = input.endpoints
 					.split(",")
 					.map((endpoint) => parseInt(endpoint.split("/").pop() || "", 10));
-				if (portNumbers.length > 1 && portNumbers[0] !== portNumbers[1]) {
-					throwError("Error: Port numbers are not equal in the provided endpoints");
-				}
+				// if (portNumbers.length > 1 && portNumbers[0] !== portNumbers[1]) {
+				// 	throwError("Error: Port numbers are not equal in the provided endpoints");
+				// }
 
 				try {
-					await updateLocalConf(portNumbers[0]);
+					await updateLocalConf(portNumbers);
 				} catch (error) {
 					throwError(error);
 				}
@@ -948,7 +948,7 @@ export const adminRouter = createTRPCRouter({
 			 *
 			 */
 			try {
-				await updateLocalConf(9993);
+				await updateLocalConf([9993]);
 			} catch (error) {
 				throwError(error);
 			}


### PR DESCRIPTION
Resolves #113

- [x] Allow users to create planetID 149604618 and birthID 1567191349589.
- [x] Set `primaryPort` , `secondaryPort` and `allowSecondaryPort` based on the endpoint ports. 

When creating a planet using the example endpoints `10.0.10.10/10000,2a02:6ea0:d405::/10001`, the local conf will look like this:
```json
{
  "settings": {
    "primaryPort": 10000,
    "portMappingEnabled": true,
    "softwareUpdate": "disable",
    "allowManagementFrom": [
      "172.31.255.0/29"
    ],
    "allowTcpFallbackRelay": true,
    "secondaryPort": 10001,
    "allowSecondaryPort": true
  }
}
```

After restoring to original:
```json
{
  "settings": {
    "primaryPort": 9993,
    "portMappingEnabled": true,
    "softwareUpdate": "disable",
    "allowManagementFrom": [
      "172.31.255.0/29"
    ],
    "allowTcpFallbackRelay": true
  }
}
```