### PR TITLE
Update ztApi.ts - change default URL of the Local Zerotier URL

### DIFF
--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -38,7 +38,7 @@ if (os.platform() === "freebsd") {
 	ZT_FILE = process.env.ZT_SECRET_FILE || `${ZT_FOLDER}/authtoken.secret`;
 }
 
-const LOCAL_ZT_ADDR = process.env.ZT_ADDR || "http://zerotier:9993";
+const LOCAL_ZT_ADDR = process.env.ZT_ADDR || "http://127.0.0.1:9993";
 const CENTRAL_ZT_ADDR = "https://api.zerotier.com/api/v1";
 
 let ZT_SECRET = process.env.ZT_SECRET;

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -26,6 +26,7 @@ import { type NetworkAndMemberResponse } from "~/types/network";
 import { UserContext } from "~/types/ctx";
 import os from "os";
 import { prisma } from "~/server/db";
+import { isRunningInDocker } from "./docker";
 
 export let ZT_FOLDER: string;
 export let ZT_FILE: string;
@@ -38,7 +39,11 @@ if (os.platform() === "freebsd") {
 	ZT_FILE = process.env.ZT_SECRET_FILE || `${ZT_FOLDER}/authtoken.secret`;
 }
 
-const LOCAL_ZT_ADDR = process.env.ZT_ADDR || "http://127.0.0.1:9993";
+const LOCAL_ZT_ADDR =
+	process.env.ZT_ADDR || isRunningInDocker()
+		? "http://zerotier:9993"
+		: "http://127.0.0.1:9993";
+
 const CENTRAL_ZT_ADDR = "https://api.zerotier.com/api/v1";
 
 let ZT_SECRET = process.env.ZT_SECRET;


### PR DESCRIPTION
I think address http://zerotier:9993 may be a bit misleading, especially for the standalone version installations. My proposition is to use by default (if not specified in .env file ZT_ADDR variable) http://127.0.0.1:9993 which should work everywhere.