### PR TITLE
update zt url during registration

### DIFF
--- a/docs/ztnet/docs/Installation/docker-compose.md
+++ b/docs/ztnet/docs/Installation/docker-compose.md
@@ -101,3 +101,16 @@ As an administrator, you possess unique capabilities not available to regular us
 
 Please note that while admins have visibility over registered accounts, they **cannot** interact with or modify other users' networks directly. Each network's configuration and data remain exclusive to the respective user account, maintaining privacy and security for all users.
 
+## Ztnet Environment Variables
+The following environment variables are available for configuration. They can be set in the `.env` file or passed directly to the docker-compose.yml file.
+
+- **ZT_ADDR**  zerotier controller address. Defaults to `http://zerotier:9993` for docker environment, and `http://127.0.0.1:9993` for standalone.
+- **ZT_SECRET** zerotier controller secret. Defaults to the content of `/var/lib/zerotier-one/authtoken.secret`.
+- **NEXT_PUBLIC_SITE_NAME** Site name. Defaults to `ZTNET`.
+- **POSTGRES_HOST** Default: postgres
+- **POSTGRES_PORT** Default: 5432
+- **POSTGRES_USER** Default: postgres
+- **POSTGRES_PASSWORD** Default: postgres
+- **POSTGRES_DB** Default: ztnet
+- **NEXTAUTH_URL** Default: "http://localhost:3000" # Change `localhost` to your production domain when deploying.
+- **NEXTAUTH_SECRET** Default: "random_secret", change this to a random string for security.

--- a/src/components/elements/inputField.tsx
+++ b/src/components/elements/inputField.tsx
@@ -101,7 +101,7 @@ const InputField = ({
 		}
 	}, [showInputs, fields]);
 
-	const handleEditClick = () => setShowInputs(!showInputs);
+	const handleEditClick = () => !disabled && setShowInputs(!showInputs);
 
 	const handleChange = (
 		e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -434,7 +434,8 @@
 				"modification_warning": "Modifying the ZeroTier controller URL affects all users. While this offers flexibility for those wanting a custom controller, be aware of potential disruptions and compatibility issues. Always backup configurations before changes.",
 				"local_zerotier_url": "Local Zerotier URL",
 				"zerotier_secret": "Zerotier Secret",
-				"submit_empty_field_default": "Submit empty field to use the default."
+				"submit_empty_field_default": "Submit empty field to use the default.",
+				"isUsingEnvVariablesAlert": "The <span>ZT_ADDR or ZT_SECRET</span> environment variable takes precedence and overrides any URL changes made through the UI. To update the respective fields via the UI, you must first remove the ZT_ADDR or ZT_SECRET environment variables."
 			},
 			"generatePlanet": {
 				"updatePlanetWarning": "Updating the planet file will modify the core structure of your ZeroTier network, impacting routes, flexibility, and potentially availability. Proceed with caution, understanding the implications.",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -434,7 +434,8 @@
 				"modification_warning": "Modificar la URL del controlador ZeroTier afecta a todos los usuarios. Aunque esto ofrece flexibilidad para aquellos que quieren un controlador personalizado, ten en cuenta las posibles interrupciones y problemas de compatibilidad. Siempre realiza una copia de seguridad de las configuraciones antes de hacer cambios.",
 				"local_zerotier_url": "URL local de Zerotier",
 				"zerotier_secret": "Secreto de Zerotier",
-				"submit_empty_field_default": "Deje el campo vacío para usar el valor predeterminado."
+				"submit_empty_field_default": "Deje el campo vacío para usar el valor predeterminado.",
+				"isUsingEnvVariablesAlert": "La variable de entorno <span>ZT_ADDR o ZT_SECRET</span> tiene prioridad y anula cualquier cambio de URL realizado a través de la interfaz de usuario. Para actualizar los campos respectivos a través de la interfaz de usuario, primero debe eliminar las variables de entorno ZT_ADDR o ZT_SECRET."
 			},
 			"generatePlanet": {
 				"updatePlanetWarning": "Actualizar el archivo del planeta modificará la estructura central de tu red ZeroTier, impactando rutas, flexibilidad y potencialmente disponibilidad. Procede con precaución, entendiendo las implicaciones.",

--- a/src/locales/no/common.json
+++ b/src/locales/no/common.json
@@ -434,7 +434,8 @@
 				"modification_warning": "Å endre ZeroTier-kontrollerens URL påvirker alle brukere. Selv om dette gir fleksibilitet for de som ønsker en tilpasset kontroller, vær oppmerksom på potensielle avbrudd og kompatibilitetsproblemer. Ta alltid sikkerhetskopi av konfigurasjoner før endringer.",
 				"local_zerotier_url": "Lokal Zerotier URL",
 				"zerotier_secret": "Zerotier Hemmelighet",
-				"submit_empty_field_default": "Send inn tomt felt for å bruke standardinnstillingen."
+				"submit_empty_field_default": "Send inn tomt felt for å bruke standardinnstillingen.",
+				"isUsingEnvVariablesAlert": "Miljøvariabelen <span>ZT_ADDR eller ZT_SECRET</span> har forrang og overstyrer eventuelle URL-endringer gjort gjennom brukergrensesnittet. For å oppdatere de respektive feltene via brukergrensesnittet, må du først fjerne ZT_ADDR eller ZT_SECRET miljøvariablene."
 			},
 			"generatePlanet": {
 				"updatePlanetWarning": "Oppdatering av planetfilen vil endre kjernestrukturen i ZeroTier-nettverket ditt, påvirke ruter, fleksibilitet og potensielt tilgjengelighet. Fortsett med forsiktighet, og forstå konsekvensene.",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -434,7 +434,8 @@
 				"modification_warning": "修改ZeroTier控制器URL会影响所有用户。虽然这为想要自定义控制器的人提供了灵活性，但请注意可能的中断和兼容性问题。更改前始终备份配置。",
 				"local_zerotier_url": "本地Zerotier URL",
 				"zerotier_secret": "Zerotier密码",
-				"submit_empty_field_default": "提交空字段以使用默认值。"
+				"submit_empty_field_default": "提交空字段以使用默认值。",
+				"isUsingEnvVariablesAlert": "环境变量<span>ZT_ADDR 或 ZT_SECRET</span>将优先覆盖通过用户界面所做的任何URL更改。要通过用户界面更新相应字段，您必须先删除ZT_ADDR或ZT_SECRET环境变量。"
 			},
 			"generatePlanet": {
 				"updatePlanetWarning": "更新planet文件将修改您的ZeroTier网络的核心结构，影响路由，灵活性和可能的可用性。小心进行，理解其中的含义。",

--- a/src/pages/admin/controller/index.tsx
+++ b/src/pages/admin/controller/index.tsx
@@ -147,6 +147,29 @@ const Controller = () => {
 							span: (content) => <span className="text-error">{content} </span>,
 						})}
 						{t("controller.controllerConfig.modification_warning")}
+						{"urlFromEnv" in (me?.options ?? {}) ? (
+							<div className="alert alert-warning my-5">
+								<svg
+									xmlns="http://www.w3.org/2000/svg"
+									className="stroke-current shrink-0 h-6 w-6"
+									fill="none"
+									viewBox="0 0 24 24"
+								>
+									<path
+										strokeLinecap="round"
+										strokeLinejoin="round"
+										strokeWidth="2"
+										d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+									/>
+								</svg>
+								<span className="font-medium">
+									The ZT_ENV environment variable is active, preventing URL changes from
+									the UI. To modify the URL, you must first remove ZT_ENV.
+								</span>
+							</div>
+						) : (
+							"nope"
+						)}
 					</p>
 
 					<EditableField

--- a/src/pages/admin/controller/index.tsx
+++ b/src/pages/admin/controller/index.tsx
@@ -24,7 +24,7 @@ const Controller = () => {
 		});
 	const { data: unlinkedNetworks, refetch: refetchUnlinkedNetworks } =
 		api.admin.unlinkedNetwork.useQuery();
-	const { data: me, refetch: refetchMe } = api.auth.me.useQuery();
+	const { data: me, refetch: refetchMe, isLoading: meLoading } = api.auth.me.useQuery();
 	const { mutate: setZtOptions } = api.auth.setLocalZt.useMutation({
 		onSuccess: () => {
 			toast.success("Successfully updated ZeroTier options");
@@ -49,6 +49,8 @@ const Controller = () => {
 		controllerStatus?.config?.settings || {};
 
 	const { online, tcpFallbackActive, version } = controllerStatus || {};
+
+	if (meLoading) return null;
 
 	return (
 		<main className="mx-auto flex w-full flex-col justify-center space-y-5 bg-base-100 p-3 sm:w-6/12 pb-80">
@@ -161,7 +163,7 @@ const Controller = () => {
 							span: (content) => <span className="text-error">{content} </span>,
 						})}
 						{t("controller.controllerConfig.modification_warning")}
-						{"urlFromEnv" in (me?.options ?? {}) ? (
+						{me?.options.urlFromEnv || me?.options.secretFromEnv ? (
 							<div className="alert alert-warning my-5">
 								<svg
 									xmlns="http://www.w3.org/2000/svg"
@@ -177,9 +179,9 @@ const Controller = () => {
 									/>
 								</svg>
 								<span className="font-medium">
-									The <span className="font-bold">ZT_ADDR</span> environment variable
-									takes precedence and overrides any URL changes made through the UI. To
-									update the URL via the UI, you must first remove ZT_ADDR.
+									{t.rich("controller.controllerConfig.isUsingEnvVariablesAlert", {
+										span: (content) => <span className="font-bold">{content} </span>,
+									})}
 								</span>
 							</div>
 						) : (
@@ -192,6 +194,7 @@ const Controller = () => {
 						label={t("controller.controllerConfig.local_zerotier_url")}
 						description={t("controller.controllerConfig.submit_empty_field_default")}
 						size="sm"
+						disabled={me?.options.urlFromEnv}
 						fields={[
 							{
 								name: "localControllerUrl",
@@ -213,6 +216,7 @@ const Controller = () => {
 						label={t("controller.controllerConfig.zerotier_secret")}
 						description={t("controller.controllerConfig.submit_empty_field_default")}
 						size="sm"
+						disabled={me?.options.secretFromEnv}
 						fields={[
 							{
 								name: "localControllerSecret",

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -261,7 +261,8 @@ export const authRouter = createTRPCRouter({
 		interface ExtendedUser extends User {
 			options?: ExtendedUserOptions;
 		}
-		// add ttype that extend the user type with urlFromEnv
+
+		// add type that extend the user type with urlFromEnv
 		const user = (await ctx.prisma.user.findFirst({
 			where: {
 				id: ctx.session.user.id,
@@ -270,7 +271,6 @@ export const authRouter = createTRPCRouter({
 				options: true,
 			},
 		})) as ExtendedUser;
-
 		if (process.env.ZT_ADDR) {
 			user.options.localControllerUrl = process.env.ZT_ADDR;
 			user.options.urlFromEnv = true;
@@ -578,6 +578,12 @@ export const authRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			if (input?.localControllerUrl && process.env.ZT_ADDR) {
+				throw new TRPCError({
+					code: "BAD_REQUEST",
+					message: "Remove the ZT_ADDR environment variable to use this feature!",
+				});
+			}
 			// we use upsert in case the user has no options yet
 			const updated = await ctx.prisma.user.update({
 				where: {

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -253,7 +253,7 @@ export const authRouter = createTRPCRouter({
 			};
 		}),
 	me: protectedProcedure.query(async ({ ctx }) => {
-		return await ctx.prisma.user.findFirst({
+		const user = await ctx.prisma.user.findFirst({
 			where: {
 				id: ctx.session.user.id,
 			},
@@ -261,6 +261,14 @@ export const authRouter = createTRPCRouter({
 				options: true,
 			},
 		});
+
+		// update placeholder url based on docker or standalone version
+		if (user?.options?.localControllerUrl) return user;
+
+		const url = isRunningInDocker() ? "http://zerotier:9993" : "http://127.0.0.1:9993";
+		user.options.localControllerUrl = url;
+
+		return user;
 	}),
 	update: protectedProcedure
 		.input(

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -18,6 +18,7 @@ import {
 import ejs from "ejs";
 import * as ztController from "~/utils/ztApi";
 import { API_TOKEN_SECRET, encrypt, generateInstanceSecret } from "~/utils/encryption";
+import { isRunningInDocker } from "~/utils/docker";
 
 // This regular expression (regex) is used to validate a password based on the following criteria:
 // - The password must be at least 6 characters long.
@@ -183,7 +184,11 @@ export const authRouter = createTRPCRouter({
 					hash,
 					userGroupId: defaultUserGroup?.id,
 					options: {
-						create: {}, // empty object will make Prisma use the default values from the model
+						create: {
+							localControllerUrl: isRunningInDocker()
+								? "http://zerotier:9993"
+								: "http://127.0.0.1:9993",
+						},
 					},
 				},
 				select: {

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -26,24 +26,19 @@ import { type NetworkAndMemberResponse } from "~/types/network";
 import { UserContext } from "~/types/ctx";
 import os from "os";
 import { prisma } from "~/server/db";
-import { isRunningInDocker } from "./docker";
 
 export let ZT_FOLDER: string;
-export let ZT_FILE: string;
 
 if (os.platform() === "freebsd") {
 	ZT_FOLDER = "/var/db/zerotier-one";
-	ZT_FILE = `${ZT_FOLDER}/authtoken.secret`;
 } else {
 	ZT_FOLDER = "/var/lib/zerotier-one";
-	ZT_FILE = process.env.ZT_SECRET_FILE || `${ZT_FOLDER}/authtoken.secret`;
 }
 
-const LOCAL_ZT_ADDR =
-	process.env.ZT_ADDR || isRunningInDocker()
-		? "http://zerotier:9993"
-		: "http://127.0.0.1:9993";
+export const ZT_FILE: string =
+	process.env.ZT_SECRET_FILE || `${ZT_FOLDER}/authtoken.secret`;
 
+const LOCAL_ZT_ADDR = process.env.ZT_ADDR;
 const CENTRAL_ZT_ADDR = "https://api.zerotier.com/api/v1";
 
 let ZT_SECRET = process.env.ZT_SECRET;
@@ -125,7 +120,7 @@ const getOptions = async (
 	}
 
 	return {
-		localControllerUrl: localControllerUrl || LOCAL_ZT_ADDR,
+		localControllerUrl: LOCAL_ZT_ADDR || localControllerUrl,
 		headers: {
 			"X-ZT1-Auth": localControllerSecret || ZT_SECRET,
 			"Content-Type": "application/json",

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -41,21 +41,19 @@ export const ZT_FILE: string =
 const LOCAL_ZT_ADDR = process.env.ZT_ADDR;
 const CENTRAL_ZT_ADDR = "https://api.zerotier.com/api/v1";
 
-let ZT_SECRET = process.env.ZT_SECRET;
-
-if (!ZT_SECRET) {
-	if (process.env.IS_GITHUB_ACTION !== "true") {
-		try {
-			ZT_SECRET = fs.readFileSync(ZT_FILE, "utf8");
-		} catch (error) {
-			console.error("an error occurred while reading the ZT_SECRET");
-			console.error(error);
-		}
-	} else {
-		// GitHub Actions
-		ZT_SECRET = "dummy_text_to_skip_gh";
-	}
-}
+const ZT_SECRET =
+	process.env.ZT_SECRET ||
+	(process.env.IS_GITHUB_ACTION === "true"
+		? "dummy_text_to_skip_gh"
+		: (() => {
+				try {
+					return fs.readFileSync(ZT_FILE, "utf8");
+				} catch (error) {
+					console.error("An error occurred while reading the ZT_SECRET");
+					console.error(error);
+					return null; // or appropriate fallback value
+				}
+		  })());
 
 const getApiCredentials = async (
 	ctx: UserContext,


### PR DESCRIPTION
follow up #196

- [x] Fixed bug when using `ZT_ADDR` or `ZT_SECRET` variables.
- [x] Using env variables will take precedence over the db values.
- [x] Inputs in UI are disabled when using envs. An alert message will be displayed.
- [x] Added translations for the alert box.

![image](https://github.com/sinamics/ztnet/assets/7771916/585778bf-a273-49f8-a467-dbb38320839c)

