### PR TITLE
Update create_dns_host.md - Allow multiple ipv4 addresses

### DIFF
--- a/docs/ztnet/docs/Usage/create_dns_host.md
+++ b/docs/ztnet/docs/Usage/create_dns_host.md
@@ -132,14 +132,16 @@ joined=$(echo "$netmembers" | \
 
   for entry in $(echo "$joined" | jq -c '.'); do
     nodeid=$(echo "$entry" | jq -r '.id')
+    nodename=$(echo "$entry" | jq -r '.name')
 
-    line=$(printf "%s\t%s.%s\t%s" \
-      $(echo "$entry" | jq -r '.ips[0]') \
-      $(echo "$entry" | jq -r '.name') \
-      "$DNSNAME" \
-      "$nodeid.$DNSNAME")
+    for ipv4_address in $(echo "$entry" | jq -r '.ips[]'); do
+      line=$(printf "%s\t%s\t%s" \
+        "$ipv4_address" \
+        "$nodename.$DNSNAME" \
+        "$nodeid.$DNSNAME")
 
-    ipv4_lines+=("$line")
+      ipv4_lines+=("$line")
+    done
   done
 
   for entry in $(echo "$joined" | jq -c '.'); do


### PR DESCRIPTION
A change in dns script to print a line with node name and node id for every ipv4 assigned to a node

For example, if we have a network with this configuration:

node-1 -> ips: 203.0.113.97,  100.80.205.233, 10.65.0.1
node-2 -> ips: 203.0.113.157, 100.80.247.32, 10.65.0.1

current script prints:

``127.0.0.1          localhost``
``203.0.113.97       node-1.zerotier.network      6dc55d88fb.zerotier.network``
``203.0.113.157      node-2.zerotier.network      fd6906b901.zerotier.network``

with my proposed change we would get:

``127.0.0.1          localhost``
``203.0.113.97       node-1.zerotier.network      6dc55d88fb.zerotier.network``
``100.80.205.233     node-1.zerotier.network      6dc55d88fb.zerotier.network``
``100.65.0.1         node-1.zerotier.network      6dc55d88fb.zerotier.network``
``203.0.113.157      node-2.zerotier.network      fd6906b901.zerotier.network``
``100.80.247.32      node-2.zerotier.network      fd6906b901.zerotier.network``
``100.65.0.2         node-2.zerotier.network      fd6906b901.zerotier.network``