### PR TITLE
Added generic OAuth authentication support

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     working_dir: /workspaces
     volumes:
       - .:/workspaces:cached
-    # environment:
-    #   NEXTAUTH_URL: "http://10.0.0.217:3000" # Update this to the URL of your dev environment
+    environment:
+      NEXTAUTH_URL: "http://10.0.0.217:3000" # Update this to the URL of your dev environment
     networks:
       - app-network
     depends_on:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -20,8 +20,8 @@ services:
     working_dir: /workspaces
     volumes:
       - .:/workspaces:cached
-    environment:
-      NEXTAUTH_URL: "http://10.0.0.217:3000" # Update this to the URL of your dev environment
+    # environment:
+    #   NEXTAUTH_URL: "http://10.0.0.217:3000" # Update this to the URL of your dev environment
     networks:
       - app-network
     depends_on:

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,10 @@ DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POS
 # https://www.prisma.io/docs/concepts/components/prisma-migrate/shadow-database
 MIGRATE_POSTGRES_DB="shaddow_ztnet"
 MIGRATE_DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localhost:${POSTGRES_PORT}/${MIGRATE_POSTGRES_DB}?schema=public"
+
+# OAuth
+OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=true
+OAUTH_WELLKNOWN="https://accounts.google.com/.well-known/openid-configuration" 
+OAUTH_ID=
+OAUTH_SECRET=
+

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - uses: actions/setup-node@master
         with:
           node-version: 18.x

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -39,10 +39,9 @@ jobs:
     name: Test Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        # checkout dev branch
+      - uses: actions/checkout@v3
         with:
-          ref: dev
+          ref: ${{ github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ztnet
-      NEXTAUTH_URL: "http://localhost:3000" # change localhost to your domain or server ip address if hosting on a server.
+      NEXTAUTH_URL: "http://10.0.0.217:3000" # change localhost to your domain or server ip address if hosting on a server.
       NEXTAUTH_SECRET: "random_secret" # change this to a random string of characters.
     networks:
       - app-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: ztnet
-      NEXTAUTH_URL: "http://10.0.0.217:3000" # change localhost to your domain or server ip address if hosting on a server.
+      NEXTAUTH_URL: "http://server_ip:3000" # change localhost to your domain or server ip address if hosting on a server.
       NEXTAUTH_SECRET: "random_secret" # change this to a random string of characters.
     networks:
       - app-network

--- a/docs/docs/Authentication/oauth.md
+++ b/docs/docs/Authentication/oauth.md
@@ -1,0 +1,103 @@
+---
+id: oauth
+title: Oauth
+slug: /authentication/oauth/
+description: OAuth Configuration Guide
+sidebar_position: 6
+---
+
+# OAuth Configuration Guide
+
+This document provides guidelines on configuring OAuth for various providers in our application. We support both standard OAuth 2.0 and OpenID Connect integrations.
+
+## OpenID Connect and Standard OAuth 2.0 Configuration
+
+Both OpenID Connect (OIDC) and Standard OAuth 2.0 are widely used for user authentication and authorization. The following environment variables are essential for configuring these protocols:
+
+- `OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING`: Set to `true` to enable the merging of user accounts that were initially created using email and password credentials with OAuth accounts. This is important for account merging and applies to both OpenID Connect and Standard OAuth 2.0 integrations. 
+
+### OpenID Connect Configuration
+
+OpenID Connect (OIDC) is an identity layer on top of the OAuth 2.0 protocol and is implemented by providers like Google. Configure the following for OIDC:
+
+- `OAUTH_ID`: Your OAuth Client ID.
+- `OAUTH_SECRET`: Your OAuth Client Secret.
+- `OAUTH_WELLKNOWN`: URL to the OpenID Connect discovery document provided by the OAuth server. For example: `http://{PROVIDER_URL}/auth/realms/{REALM}/.well-known/openid-configuration`.
+
+### Standard OAuth 2.0 Configuration
+
+Standard OAuth 2.0 is used by various providers, including GitHub and Facebook. Set the following environment variables for OAuth 2.0 providers:
+
+- `OAUTH_ID`: The OAuth Client ID.
+- `OAUTH_SECRET`: The OAuth Client Secret.
+- `OAUTH_ACCESS_TOKEN_URL`: URL to obtain the access token. For example: `"https://github.com/login/oauth/access_token"`.
+- `OAUTH_AUTHORIZATION_URL`: URL to redirect users for authentication. It should be generated in the provider's developer settings. For example: `"https://github.com/login/oauth/authorize"` for GitHub.
+- `OAUTH_USER_INFO`: URL to fetch the user's profile information after authentication. For example: `"https://api.github.com/user"` for GitHub.
+- `OAUTH_SCOPE`: Defines the scope of access. For example: `"read:user user:email"` for GitHub.
+
+
+## Examples
+
+### Keycloak Configuration
+docker-compose.yml
+```yml
+ztnet:
+  image: sinamics/ztnet:latest
+  ...
+  environment:
+    OAUTH_ID=your-client-id
+    OAUTH_SECRET=your-client-secret
+    OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=true
+    OAUTH_WELLKNOWN="http://{PROVIDER_URL}/auth/realms/{REALM}/.well-known/openid-configuration"
+```
+
+### GitHub Configuration
+
+Documentation: https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps
+```yml
+ztnet:
+  image: sinamics/ztnet:latest
+  ...
+  environment:
+    OAUTH_ID=your-github-client-id
+    OAUTH_SECRET=your-github-client-secret
+    OAUTH_ACCESS_TOKEN_URL="https://github.com/login/oauth/access_token"
+    OAUTH_AUTHORIZATION_URL="https://github.com/login/oauth/authorize"
+    OAUTH_USER_INFO="https://api.github.com/user"
+    OAUTH_SCOPE="read:user user:email"
+```
+
+### Facebook Configuration
+
+Documentation: https://developers.facebook.com/docs/facebook-login/manually-build-a-login-flow/
+```yml
+ztnet:
+  image: sinamics/ztnet:latest
+  ...
+  environment:
+    OAUTH_ID=your-facebook-client-id
+    OAUTH_SECRET=your-facebook-client-secret
+    OAUTH_ACCESS_TOKEN_URL="https://graph.facebook.com/oauth/access_token"
+    OAUTH_AUTHORIZATION_URL="https://www.facebook.com/v11.0/dialog/oauth?scope=email"
+    OAUTH_USER_INFO="https://graph.facebook.com/me"
+    OAUTH_SCOPE="id,name,email,picture"
+```
+
+### Discord Configuration
+
+Documentation: https://discord.com/developers/docs/topics/oauth2
+**Note* on `OAUTH_AUTHORIZATION_URL`  
+When configuring the OAUTH_AUTHORIZATION_URL, it is important to generate it properly within your Discord application's developer settings. This URL contains critical parameters such as the client_id, response_type, redirect_uri, and scope. The redirect_uri must be precisely the same as the one registered in your Discord application to ensure successful redirection and authentication.
+```yml
+ztnet:
+  image: sinamics/ztnet:latest
+  ...
+  environment:
+    OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=true
+    OAUTH_ID=your-discord-client-id
+    OAUTH_SECRET=your-discord-client-secret
+    OAUTH_ACCESS_TOKEN_URL="https://discord.com/api/oauth2/token"
+    OAUTH_AUTHORIZATION_URL="https://discord.com/api/oauth2/authorize?client_id=xxxx&response_type=code&redirect_uri=https%3A%2F%2Fawesome.ztnet.com%2Fapi%2Fauth%2Fcallback%2Foauth&scope=email+identify"
+    OAUTH_USER_INFO="https://discord.com/api/users/@me"
+```
+

--- a/docs/docs/Installation/options.md
+++ b/docs/docs/Installation/options.md
@@ -35,19 +35,22 @@ NEXT_PUBLIC_SITE_NAME="ZTNET"
 ## Available Environment options
 
 Configure the application using the following environment variables:
-
-- `ZT_ADDR`
-  - Description: ZeroTier controller address.
-  - Default: `http://zerotier:9993` for Docker environment, and `http://127.0.0.1:9993` for standalone.
-
-- `ZT_SECRET`
-  - Description: ZeroTier controller secret.
-  - Default: Contents of `/var/lib/zerotier-one/authtoken.secret`.
-
+### ZTNET Configuration
 - `NEXT_PUBLIC_SITE_NAME`
   - Description: Site name.
   - Default: `ZTNET`.
 
+### ZeroTier Controller Configuration
+- `ZT_ADDR`
+  - Description: ZeroTier controller address. Use these settings if you wish to configure a custom ZeroTier controller instead of the default one.
+  - Default: `http://zerotier:9993` for Docker environment, and `http://127.0.0.1:9993` for standalone.
+
+- `ZT_SECRET`
+  - Description: ZeroTier controller secret. Necessary for custom controller configuration.
+  - Default: Contents of `/var/lib/zerotier-one/authtoken.secret`.
+
+
+### Database Configuration
 - `POSTGRES_HOST`
   - Default: `postgres`.
 
@@ -62,6 +65,50 @@ Configure the application using the following environment variables:
 
 - `POSTGRES_DB`
   - Default: `ztnet`.
+
+## OAuth Configuration
+See [OAuth](/authentication/oauth) for more information.
+- `OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING`
+  - Description: Allows linking of user accounts registered with email credentials to OAuth accounts. This should be enabled if a user has initially registered using email and password and later chooses to log in via OAuth, facilitating account merging.
+  - Default: `false`
+
+- `OAUTH_WELLKNOWN`
+  - Description: URL to the OAuth server's well-known configuration. 
+  - Examples:
+    - For Google: `https://accounts.google.com/.well-known/openid-configuration`
+    - For Keycloak: `http://{KEYCLOAK_SERVER_URL}/auth/realms/{REALM}/.well-known/openid-configuration`
+  - Default: None. Must be set.
+
+- `OAUTH_ID`
+  - Description: Client ID for OAuth authentication.
+  - Default: None. Must be set.
+
+- `OAUTH_SECRET`
+  - Description: Client secret for OAuth authentication.
+  - Default: None. Must be set.
+
+- `OAUTH_ACCESS_TOKEN_URL`
+  - Description: URL to obtain the access token in OAuth 2.0 flow. Used by OAuth providers to exchange authorization code for an access token.
+  - Example: `"https://github.com/login/oauth/access_token"` for GitHub.
+  - Default: None. Must be set according to the OAuth provider.
+
+- `OAUTH_AUTHORIZATION_URL`
+  - Description: URL where the application redirects users for authentication and authorization. Initiates the OAuth 2.0 authorization flow.
+  - Example: `"https://github.com/login/oauth/authorize"` for GitHub.
+  - Default: None. Must be set according to the OAuth provider.
+
+- `OAUTH_USER_INFO`
+  - Description: URL to fetch the user's profile information after successful authentication in OAuth 2.0 flow. Used to retrieve details about the authenticated user.
+  - Example: `"https://api.github.com/user"` for GitHub.
+  - Default: None. Must be set according to the OAuth provider.
+
+- `OAUTH_SCOPE`
+  - Description: Specifies the scope of access requests in the OAuth 2.0 flow. This defines the level of access that the application is requesting from the user's account. Varies depending on the OAuth provider and the information the application needs.
+  - Example: `"read:user user:email"` for GitHub, to request basic user information and email.
+  - Default: `"openid profile email"`.
+
+## NEXTAUTH Configuration
+For more information on NEXTAUTH environment variables, see [NEXTAUTH Environment Variables](https://next-auth.js.org/configuration/options#environment-variables).
 
 - `NEXTAUTH_URL`
   - Description: Canonical URL of your site.
@@ -80,4 +127,3 @@ Configure the application using the following environment variables:
   - Default: 2592000 (30 Days).
 
 
-For more information on NEXTAUTH environment variables, see [NEXTAUTH Environment Variables](https://next-auth.js.org/configuration/options#environment-variables).

--- a/prisma/migrations/20231222102756_oauth/migration.sql
+++ b/prisma/migrations/20231222102756_oauth/migration.sql
@@ -1,0 +1,18 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[provider,providerAccountId]` on the table `Account` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `provider` to the `Account` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `providerAccountId` to the `Account` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Account" ADD COLUMN     "provider" TEXT NOT NULL,
+ADD COLUMN     "providerAccountId" TEXT NOT NULL,
+ADD COLUMN     "refresh_expires_in" INTEGER;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "hash" DROP NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Account_provider_providerAccountId_key" ON "Account"("provider", "providerAccountId");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -211,7 +211,7 @@ model User {
     online                                Boolean?                @default(false)
     role                                  Role                    @default(USER)
     image                                 String?
-    hash                                  String
+    hash                                  String?
     licenseStatus                         String?
     orderStatus                           String?
     orderId                               Int                     @default(0)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -124,27 +124,33 @@ model NetworkMemberNotation {
 
 // Necessary for Next auth
 model Account {
-    id                String  @id @default(cuid())
-    userId            String
-    type              String
-    refresh_token     String? // @db.Text
-    access_token      String? // @db.Text
-    expires_at        Int?
-    token_type        String?
-    scope             String?
-    id_token          String? // @db.Text
-    session_state     String?
-    user              User    @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id                 String  @id @default(cuid())
+  userId             String
+  type               String
+  provider           String
+  providerAccountId  String
+  refresh_token      String?  @db.Text
+  access_token       String?  @db.Text
+  expires_at         Int?
+  refresh_expires_in Int?
+  token_type         String?
+  scope              String?
+  id_token           String?  @db.Text
+  session_state      String?
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@unique([provider, providerAccountId])
 }
+
 
 model Session {
-    id           String   @id @default(cuid())
-    sessionToken String   @unique
-    userId       String
-    expires      DateTime
-    user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  id           String   @id @default(cuid())
+  sessionToken String   @unique
+  userId       String
+  expires      DateTime
+  user         User     @relation(fields: [userId], references: [id], onDelete: Cascade)
 }
-
 model UserOptions {
   id                   Int       @id @default(autoincrement())
   userId               String    @unique
@@ -235,11 +241,11 @@ model User {
 
 
 model VerificationToken {
-    identifier String
-    token      String   @unique
-    expires    DateTime
+  identifier String
+  token      String   @unique
+  expires    DateTime
 
-    @@unique([identifier, token])
+  @@unique([identifier, token])
 }
 
 model UserInvitation {

--- a/src/__tests__/components/loginForm.test.tsx
+++ b/src/__tests__/components/loginForm.test.tsx
@@ -21,12 +21,20 @@ describe("LoginForm", () => {
 	});
 
 	it("renders the LoginForm component", () => {
-		render(<LoginForm />);
+		// Mock the router to simulate an OAuth
+		(useRouter as jest.Mock).mockReturnValue({
+			query: { error: "OAuthError" },
+		});
+		render(<LoginForm hasOauth />);
 		expect(screen.getByRole("heading", { name: /Sign In/i })).toBeInTheDocument();
 	});
 
 	it("updates email and password inputs on change", () => {
-		render(<LoginForm />);
+		// Mock the router to simulate an OAuth
+		(useRouter as jest.Mock).mockReturnValue({
+			query: { error: "OAuthError" },
+		});
+		render(<LoginForm hasOauth />);
 
 		const emailInput = screen.getByPlaceholderText("mail@example.com");
 		const passwordInput = screen.getByPlaceholderText("Enter your password");
@@ -39,7 +47,11 @@ describe("LoginForm", () => {
 	});
 
 	it("submits the form with correct email and password", async () => {
-		render(<LoginForm />);
+		// Mock the router to simulate an OAuth
+		(useRouter as jest.Mock).mockReturnValue({
+			query: { error: "OAuthError" },
+		});
+		render(<LoginForm hasOauth />);
 
 		(signIn as jest.Mock).mockResolvedValue({});
 

--- a/src/components/auth/forgotPasswordForm.tsx
+++ b/src/components/auth/forgotPasswordForm.tsx
@@ -54,20 +54,18 @@ const ForgotPasswordForm: React.FC = () => {
 	};
 	return (
 		<div className="z-10 flex justify-center  self-center">
-			<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300 bg-base-200 dark:bg-gray-100 p-12">
+			<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300 p-12">
 				<div className="mb-4">
-					<h3 className="text-2xl font-semibold text-gray-800">Forgot Password </h3>
+					<h3 className="text-2xl font-semibold">Forgot Password </h3>
 					<p className="text-gray-500">
 						We will send you a reset link if the email exist
 					</p>
 				</div>
 				<form className="space-y-5" onSubmit={submitHandler}>
 					<div className="space-y-2">
-						<label className="text-sm font-medium tracking-wide text-gray-700">
-							Email
-						</label>
+						<label className="text-sm font-medium tracking-wide">Email</label>
 						<input
-							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 							value={formData.email}
 							onChange={handleChange}
 							type="email"
@@ -79,7 +77,7 @@ const ForgotPasswordForm: React.FC = () => {
 						<button
 							type="submit"
 							className={cn(
-								"btn btn-block cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg",
+								"btn btn-block btn-primary cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg",
 							)}
 						>
 							{loading ? <span className="loading loading-spinner"></span> : null}

--- a/src/components/auth/loginForm.tsx
+++ b/src/components/auth/loginForm.tsx
@@ -80,16 +80,14 @@ const LoginForm: React.FC<IProps> = ({ hasOauth }) => {
 	};
 	return (
 		<div className="z-10 flex justify-center self-center">
-			<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300 bg-base-200 dark:bg-gray-100 p-12">
+			<div className="w-100 mx-auto rounded-2xl border border-1 p-12">
 				<div className="mb-4">
-					<h3 className="text-2xl font-semibold text-gray-800">Sign In </h3>
+					<h3 className="text-2xl font-semibold ">Sign In </h3>
 					<p className="text-gray-500">Please sign in to your account.</p>
 				</div>
-				<form className="space-y-5" onSubmit={submitHandler}>
+				<form className="space-y-2" onSubmit={submitHandler}>
 					<div className="space-y-2">
-						<label className="text-sm font-medium tracking-wide text-gray-700">
-							Email
-						</label>
+						<label className="text-sm font-medium tracking-wide">Email</label>
 						<input
 							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
 							value={formData.email}
@@ -100,9 +98,7 @@ const LoginForm: React.FC<IProps> = ({ hasOauth }) => {
 						/>
 					</div>
 					<div className="space-y-2">
-						<label className="mb-5 text-sm font-medium tracking-wide text-gray-700">
-							Password
-						</label>
+						<label className="mb-5 text-sm font-medium tracking-wide">Password</label>
 						<input
 							className="w-full content-center rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
 							value={formData.password}
@@ -122,25 +118,11 @@ const LoginForm: React.FC<IProps> = ({ hasOauth }) => {
 							</Link>
 						</div>
 					</div>
-					{hasOauth ? (
-						<div>
-							<button
-								type="button"
-								onClick={(e) => oAuthHandler(e)}
-								className={cn(
-									"btn btn-block btn-primary cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg",
-								)}
-							>
-								{loading.oauth ? <span className="loading loading-spinner"></span> : null}
-								oAuth
-							</button>
-						</div>
-					) : null}
-					<div>
+					<div className="pt-5">
 						<button
 							type="submit"
 							className={cn(
-								"btn btn-block cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg",
+								"btn btn-block btn-primary border cursor-pointer rounded-full font-semibold tracking-wide shadow-lg",
 							)}
 						>
 							{loading.credentials ? (
@@ -149,6 +131,27 @@ const LoginForm: React.FC<IProps> = ({ hasOauth }) => {
 							Sign in
 						</button>
 					</div>
+					{hasOauth ? (
+						<>
+							<div className="flex flex-col w-full">
+								<div className="divider divider-error">OR</div>
+							</div>
+							<div>
+								<button
+									type="button"
+									onClick={(e) => oAuthHandler(e)}
+									className={cn(
+										"btn btn-block btn-primary cursor-pointer rounded-full font-semibold tracking-wide shadow-lg",
+									)}
+								>
+									{loading.oauth ? (
+										<span className="loading loading-spinner"></span>
+									) : null}
+									Sign in with oAuth
+								</button>
+							</div>
+						</>
+					) : null}
 				</form>
 				<div className="pt-5 text-center text-xs text-gray-400">
 					<span>Copyright © {new Date().getFullYear()} Kodea Solutions</span>

--- a/src/components/auth/registerForm.tsx
+++ b/src/components/auth/registerForm.tsx
@@ -61,19 +61,17 @@ const RegisterForm: React.FC = () => {
 	};
 	return (
 		<div className="z-10 flex justify-center  self-center">
-			<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300 bg-base-200 dark:bg-gray-100 p-12">
+			<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300  p-12">
 				<div className="mb-4">
-					<h3 className="text-2xl font-semibold text-gray-800">Register </h3>
+					<h3 className="text-2xl font-semibold ">Register </h3>
 					<p className="text-gray-500">Please sign up with your credentials</p>
 				</div>
 				<form className="space-y-5" onSubmit={submitHandler}>
 					{invite ? (
 						<div className="space-y-2">
-							<label className="text-sm font-medium tracking-wide text-gray-700">
-								Code
-							</label>
+							<label className="text-sm font-medium tracking-wide">Code</label>
 							<input
-								className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+								className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 								value={formData.ztnetToken}
 								onChange={handleChange}
 								type=""
@@ -83,11 +81,9 @@ const RegisterForm: React.FC = () => {
 						</div>
 					) : null}
 					<div className="space-y-2">
-						<label className="text-sm font-medium tracking-wide text-gray-700">
-							Name
-						</label>
+						<label className="text-sm font-medium tracking-wide">Name</label>
 						<input
-							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 							value={formData.name}
 							onChange={handleChange}
 							type=""
@@ -96,11 +92,9 @@ const RegisterForm: React.FC = () => {
 						/>
 					</div>
 					<div className="space-y-2">
-						<label className="text-sm font-medium tracking-wide text-gray-700">
-							Email
-						</label>
+						<label className="text-sm font-medium tracking-wide">Email</label>
 						<input
-							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+							className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 							value={formData.email}
 							onChange={handleChange}
 							type="email"
@@ -109,11 +103,9 @@ const RegisterForm: React.FC = () => {
 						/>
 					</div>
 					<div className="space-y-2">
-						<label className="mb-5 text-sm font-medium tracking-wide text-gray-700">
-							Password
-						</label>
+						<label className="mb-5 text-sm font-medium tracking-wide">Password</label>
 						<input
-							className="w-full content-center rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+							className="w-full content-center rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 							value={formData.password}
 							onChange={handleChange}
 							type="password"
@@ -125,7 +117,7 @@ const RegisterForm: React.FC = () => {
 						<button
 							type="submit"
 							className={cn(
-								"btn btn-block cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg",
+								"btn btn-block btn-primary cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg",
 							)}
 						>
 							{loading ? <span className="loading loading-spinner"></span> : null}

--- a/src/components/layouts/layout.tsx
+++ b/src/components/layouts/layout.tsx
@@ -40,7 +40,7 @@ export const LayoutPublic = ({ children }: Props): JSX.Element => {
 							href={
 								currentPath.includes("/auth/register") ? "/auth/login" : "/auth/register"
 							}
-							className="btn"
+							className="btn btn-primary"
 						>
 							{currentPath === "/auth/register" ? "Login" : "Sign Up"}
 						</Link>

--- a/src/pages/auth/forgotPassword/reset/index.tsx
+++ b/src/pages/auth/forgotPassword/reset/index.tsx
@@ -61,18 +61,16 @@ const ForgotPassword = () => {
 				<meta name="robots" content="noindex, nofollow" />
 			</Head>
 			<div className="z-10 flex h-screen w-screen items-center justify-center">
-				<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300 bg-base-200 dark:bg-gray-100 p-12">
+				<div className="w-100 mx-auto rounded-2xl border border-1 border-base-300 p-12">
 					<div className="mb-4">
-						<h3 className="text-2xl font-semibold text-gray-800">Reset Password</h3>
+						<h3 className="text-2xl font-semibold">Reset Password</h3>
 						<p className="text-gray-500">Please enter your new password</p>
 					</div>
 					<form className="space-y-5">
 						<div className="space-y-2">
-							<label className="text-sm font-medium tracking-wide text-gray-700">
-								Password
-							</label>
+							<label className="text-sm font-medium tracking-wide">Password</label>
 							<input
-								className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+								className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 								value={state.password}
 								onChange={handleChange}
 								type="password"
@@ -81,11 +79,11 @@ const ForgotPassword = () => {
 							/>
 						</div>
 						<div className="space-y-2">
-							<label className="text-sm font-medium tracking-wide text-gray-700">
+							<label className="text-sm font-medium tracking-wide">
 								Confirm New Password
 							</label>
 							<input
-								className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-green-400 focus:outline-none"
+								className=" w-full rounded-lg border border-gray-300 px-4  py-2 text-base focus:border-primary/25 focus:outline-none"
 								value={state.newPassword}
 								onChange={handleChange}
 								type="password"
@@ -97,7 +95,7 @@ const ForgotPassword = () => {
 							<button
 								type="submit"
 								onClick={handleSubmit}
-								className="btn btn-block cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg"
+								className="btn btn-block btn-primary cursor-pointer rounded-full p-3 font-semibold tracking-wide shadow-lg"
 							>
 								Reset Password
 							</button>

--- a/src/pages/auth/login/index.tsx
+++ b/src/pages/auth/login/index.tsx
@@ -8,7 +8,7 @@ import { LayoutPublic } from "~/components/layouts/layout";
 import LoginForm from "~/components/auth/loginForm";
 import { WelcomeMessage } from "~/components/auth/welcomeMessage";
 
-const Login = (props) => {
+const Login = ({ hasOauth }) => {
 	const title = `${globalSiteTitle} - Sign In`;
 
 	return (
@@ -24,7 +24,7 @@ const Login = (props) => {
 				<div className="flex flex-grow items-center">
 					<div className="mx-auto flex">
 						<WelcomeMessage />
-						<LoginForm hasOauth={props} />
+						<LoginForm hasOauth={hasOauth} />
 					</div>
 				</div>
 			</main>

--- a/src/pages/auth/login/index.tsx
+++ b/src/pages/auth/login/index.tsx
@@ -8,8 +8,9 @@ import { LayoutPublic } from "~/components/layouts/layout";
 import LoginForm from "~/components/auth/loginForm";
 import { WelcomeMessage } from "~/components/auth/welcomeMessage";
 
-const Login = () => {
+const Login = (props) => {
 	const title = `${globalSiteTitle} - Sign In`;
+
 	return (
 		<>
 			<Head>
@@ -23,7 +24,7 @@ const Login = () => {
 				<div className="flex flex-grow items-center">
 					<div className="mx-auto flex">
 						<WelcomeMessage />
-						<LoginForm />
+						<LoginForm hasOauth={props} />
 					</div>
 				</div>
 			</main>
@@ -38,9 +39,11 @@ interface Props {
 export const getServerSideProps: GetServerSideProps<Props> = async (
 	context: GetServerSidePropsContext,
 ) => {
+	const hasOauth = !!(process.env.OAUTH_ID && process.env.OAUTH_SECRET);
+
 	const session = await getSession(context);
-	if (!session || !("user" in session)) {
-		return { props: {} };
+	if (!session || !session.user) {
+		return { props: { hasOauth } };
 	}
 
 	if (session.user) {

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -42,7 +42,7 @@ const MyAdapter = {
 	...prismaAdapter,
 	linkAccount: (account) => {
 		// biome-ignore lint/correctness/noUnusedVariables: <explanation>
-		const { refresh_expires_in, ...rest } = account;
+		const { refresh_expires_in, "not-before-policy": _, ...rest } = account;
 		return prismaAdapter.linkAccount(rest);
 	},
 };

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -5,7 +5,7 @@ import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { prisma } from "~/server/db";
 import { compare } from "bcryptjs";
 import { type User as IUser } from "@prisma/client";
-// import { type User } from ".prisma/client";
+import { isRunningInDocker } from "~/utils/docker";
 
 /**
  * Module augmentation for `next-auth` types. Allows us to add custom properties to the `session`
@@ -34,14 +34,55 @@ declare module "next-auth" {
 	}
 }
 
+const prismaAdapter = PrismaAdapter(prisma);
+
+// fix for oauth
+// https://github.com/nextauthjs/next-auth/issues/3823
+const MyAdapter = {
+	...prismaAdapter,
+	linkAccount: (account) => {
+		// biome-ignore lint/correctness/noUnusedVariables: <explanation>
+		const { refresh_expires_in, ...rest } = account;
+		return prismaAdapter.linkAccount(rest);
+	},
+};
+
 /**
  * Options for NextAuth.js used to configure adapters, providers, callbacks, etc.
  *
  * @see https://next-auth.js.org/configuration/options
  */
 export const authOptions: NextAuthOptions = {
-	adapter: PrismaAdapter(prisma),
+	adapter: MyAdapter,
 	providers: [
+		{
+			id: "oauth",
+			name: "Oauth",
+			type: "oauth",
+			allowDangerousEmailAccountLinking:
+				Boolean(process.env.OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING) || true,
+			wellKnown: process.env.OAUTH_WELLKNOWN,
+			clientId: process.env.OAUTH_ID,
+			clientSecret: process.env.OAUTH_SECRET,
+			idToken: true,
+			checks: ["pkce", "state"],
+			authorization: {
+				params: {
+					scope: "openid profile email",
+				},
+			},
+			profile(profile) {
+				return Promise.resolve({
+					id: profile.sub,
+					name: profile.name,
+					email: profile.email,
+					image: profile.picture,
+					lastLogin: new Date().toISOString(),
+					role: "USER",
+				});
+			},
+		},
+
 		CredentialsProvider({
 			// The name to display on the sign in form (e.g. "Sign in with...")
 			name: "Credentials",
@@ -105,6 +146,67 @@ export const authOptions: NextAuthOptions = {
 		maxAge: parseInt(process.env.NEXTAUTH_SESSION_MAX_AGE, 10) || 30 * 24 * 60 * 60, // 30 Days
 	},
 	callbacks: {
+		/**
+		 * @see https://next-auth.js.org/configuration/callbacks#sign-in-callback
+		 */
+		async signIn({ user, account }) {
+			if (account.provider === "credentials") {
+				return true;
+			}
+			if (account.provider === "oauth") {
+				// Check if the user already exists
+				const existingUser = await prisma.user.findUnique({
+					where: {
+						email: user.email,
+					},
+				});
+
+				if (existingUser) {
+					// User exists, update last login or other fields as necessary
+					await prisma.user.update({
+						where: {
+							id: existingUser.id,
+						},
+						data: {
+							lastLogin: new Date().toISOString(),
+						},
+					});
+				} else {
+					// User does not exist, create new user
+					const userCount = await prisma.user.count();
+					const defaultUserGroup = await prisma.userGroup.findFirst({
+						where: {
+							isDefault: true,
+						},
+					});
+
+					await prisma.user.create({
+						data: {
+							name: user.name,
+							email: user.email,
+							lastLogin: new Date().toISOString(),
+							role: userCount === 0 ? "ADMIN" : "USER",
+							image: user.image,
+							userGroupId: defaultUserGroup?.id,
+							options: {
+								create: {
+									localControllerUrl: isRunningInDocker()
+										? "http://zerotier:9993"
+										: "http://127.0.0.1:9993",
+								},
+							},
+						},
+						select: {
+							id: true,
+							name: true,
+							email: true,
+							role: true,
+						},
+					});
+				}
+				return true;
+			}
+		},
 		async jwt({ token, user, trigger, account, session }) {
 			if (trigger === "update") {
 				if (session.update) {
@@ -160,8 +262,16 @@ export const authOptions: NextAuthOptions = {
 			}
 
 			// Persist the OAuth access_token to the token right after signin
-			if (account) {
+			// Handle OAuth login
+			if (account && user) {
+				// Persist OAuth token to the JWT
 				token.accessToken = account.accessToken;
+
+				// Update token with user information
+				token.id = user.id;
+				token.name = user.name;
+				token.email = user.email;
+				token.role = user.role; // Add other relevant properties as needed
 			}
 			if (user) {
 				// token.id = user.id;
@@ -196,6 +306,7 @@ export const authOptions: NextAuthOptions = {
 	},
 	pages: {
 		signIn: "/auth/login",
+		error: "/auth/error",
 	},
 	debug: false,
 };

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,6 +2,11 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer components {
+  .btn{
+    text-transform: uppercase;
+  }
+}
 .outer-content{
   min-height: 100dvh;
 }
@@ -48,3 +53,6 @@ td {
   border: 1px solid black;
   border-collapse: collapse;
 } */
+.theme-black {
+  text-transform: none; /* This prevents text from being transformed to lowercase */
+}

--- a/src/utils/encryption.ts
+++ b/src/utils/encryption.ts
@@ -6,6 +6,7 @@ const ZTNET_SECRET = process.env.NEXTAUTH_SECRET;
 export const SMTP_SECRET = "_smtp";
 export const API_TOKEN_SECRET = "_ztnet_api_token";
 export const ORG_INVITE_TOKEN_SECRET = "_ztnet_org_invite";
+export const PASSWORD_RESET_SECRET = "_ztnet_org_invite";
 
 // Generate instance specific auth secret using salt
 export const generateInstanceSecret = (contextSuffix: string) => {

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -50,33 +50,6 @@ const config = {
 			"forest",
 		],
 	},
-	// daisyui: {
-	//   themes: [
-	//     {
-	//       "[data-theme=dark]": {
-	//         "color-scheme": "dark",
-	//         primary: "#661AE6",
-	//         "primary-content": "#ffffff",
-	//         secondary: "#D926AA",
-	//         "secondary-content": "#ffffff",
-	//         accent: "#1FB2A5",
-	//         "accent-content": "#ffffff",
-	//         neutral: "#191D24",
-	//         "neutral-focus": "#111318",
-	//         "neutral-content": "#A6ADBB",
-	//         "base-100": "#2A303C",
-	//         "base-200": "#242933",
-	//         "base-300": "#20252E",
-	//         "base-content": "#A6ADBB",
-	//       },
-	//     },
-	//   ],
-	// },
-	// themes: [
-	//   "light",
-	//   "dark",
-	//   "black",
-	// ],
 };
 
 module.exports = config;

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -22,7 +22,7 @@ const config = {
 			{
 				dark: {
 					primary: "#7e22ce",
-					"primary-focus": "#570df8",
+					"primary-focus": "#711eb9",
 					"primary-content": "#ffffff",
 					secondary: "#e5e7eb",
 					"secondary-focus": "#bd0091",


### PR DESCRIPTION
- [x] Add new env variables to configure the oauth
- [x] Show new oauth button if env is present.
- [x] Update documentation

**Notes!**
- If user has registered to the application using credentails, we need to set the `OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING` that will allow to merge the accounts. 
- If user signin using oauth and then set`s a password from the user-settings, he will be able to login using both credentials and oauth.

Tested with `Keycloak`, `Google`, `Github` and `Discord`

### Keycloak Configuration
```yml
ztnet:
  image: sinamics/ztnet:latest
  ...
  environment:
    OAUTH_ID=your-client-id
    OAUTH_SECRET=your-client-secret
    OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=true
    OAUTH_WELLKNOWN="http://{PROVIDER_URL}/auth/realms/{REALM}/.well-known/openid-configuration"
```

### GitHub Configuration
```yml
ztnet:
  image: sinamics/ztnet:latest
  ...
  environment:
    OAUTH_ID=your-github-client-id
    OAUTH_SECRET=your-github-client-secret
    OAUTH_ACCESS_TOKEN_URL="https://github.com/login/oauth/access_token"
    OAUTH_AUTHORIZATION_URL="https://github.com/login/oauth/authorize"
    OAUTH_USER_INFO="https://api.github.com/user"
    OAUTH_SCOPE="read:user user:email"
```


Resolves #168
