### PR TITLE
Update network members in DB when user if offline.

### DIFF
--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -96,6 +96,13 @@ export const CheckExpiredUsers = async () => {
 	);
 };
 
+/**
+ * Updates the peers for all active users and their networks.
+ * This function is scheduled to run periodically using a cron job.
+ *
+ * Run every 5 minutes and if user is offline. There is no reason to update if the user is online.
+ * https://github.com/sinamics/ztnet/issues/313
+ */
 export const updatePeers = async () => {
 	new cron.CronJob(
 		// updates every 5 minutes
@@ -156,9 +163,13 @@ export const updatePeers = async () => {
 							context,
 							ztControllerResponse.members,
 						);
-
-						// @ts-expect-error
-						await syncMemberPeersAndStatus(context, enrichedMembers, peersForAllMembers);
+						await syncMemberPeersAndStatus(
+							// @ts-expect-error
+							context,
+							network?.nwid,
+							ztControllerResponse.members,
+							peersForAllMembers,
+						);
 					}
 				}
 			} catch (error) {

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -129,7 +129,7 @@ export const updatePeers = async () => {
 				const now = new Date();
 				const fiveMinutesAgo = new Date(now.getTime() - 5 * 60000);
 				const activeUsers = users.filter((user) => {
-					return user?.lastseen < fiveMinutesAgo;
+					return user?.lastseen && new Date(user.lastseen) < fiveMinutesAgo;
 				});
 
 				// fetch all networks for each user

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -125,15 +125,15 @@ export const updatePeers = async () => {
 				// if no users return
 				if (users.length === 0) return;
 
-				// Get all users that have been active in the last 5 minutes
+				// Get all users that have been inactive for 5 minutes
 				const now = new Date();
 				const fiveMinutesAgo = new Date(now.getTime() - 5 * 60000);
-				const activeUsers = users.filter((user) => {
+				const inactiveUsers = users.filter((user) => {
 					return user?.lastseen && new Date(user.lastseen) < fiveMinutesAgo;
 				});
 
 				// fetch all networks for each user
-				for (const user of activeUsers) {
+				for (const user of inactiveUsers) {
 					const networks = await prisma.network.findMany({
 						where: {
 							authorId: user.id,

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -107,8 +107,8 @@ export const updatePeers = async () => {
 	new cron.CronJob(
 		// updates every 5 minutes
 
-		"*/10 * * * * *", // every 10 seconds ( testing )
-		// "*/5 * * * *", // every 5min
+		// "*/10 * * * * *", // every 10 seconds ( testing )
+		"*/5 * * * *", // every 5min
 		async () => {
 			try {
 				// fetch all users
@@ -118,14 +118,22 @@ export const updatePeers = async () => {
 					},
 					select: {
 						id: true,
+						lastseen: true,
 					},
 				});
 
 				// if no users return
 				if (users.length === 0) return;
 
-				// fetch all members for each user
-				for (const user of users) {
+				// Get all users that have been active in the last 5 minutes
+				const now = new Date();
+				const fiveMinutesAgo = new Date(now.getTime() - 5 * 60000);
+				const activeUsers = users.filter((user) => {
+					return user?.lastseen < fiveMinutesAgo;
+				});
+
+				// fetch all networks for each user
+				for (const user of activeUsers) {
 					const networks = await prisma.network.findMany({
 						where: {
 							authorId: user.id,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -6,8 +6,8 @@ export async function register() {
 		}
 
 		// update lastseen for all members
-		// if (cronTasksModule.updatePeers) {
-		// 	cronTasksModule.updatePeers();
-		// }
+		if (cronTasksModule.updatePeers) {
+			cronTasksModule.updatePeers();
+		}
 	}
 }

--- a/src/server/api/services/memberService.ts
+++ b/src/server/api/services/memberService.ts
@@ -94,7 +94,6 @@ export const syncMemberPeersAndStatus = async (
 				where: { nwid: updatedMember.nwid, id: updatedMember.id },
 				data: updateData,
 			});
-
 			// If the member was not found in the database, add it
 			if (updateResult.count === 0) {
 				await addNetworkMember(ctx, updatedMember).catch(console.error);
@@ -121,7 +120,7 @@ const findActivePreferredPeerPath = (peers: Peers) => {
 	const { paths } = peers;
 	const res = paths.find((path) => path?.active && path?.preferred);
 
-	return { res, ...peers };
+	return { ...res, ...peers };
 };
 
 /**
@@ -132,7 +131,7 @@ const findActivePreferredPeerPath = (peers: Peers) => {
  * @returns A promise that resolves to the created network member.
  */
 const addNetworkMember = async (ctx, member: MemberEntity) => {
-	const user = await ctx.prisma.user.findFirst({
+	const user = await prisma.user.findFirst({
 		where: {
 			id: ctx.session.user.id,
 		},

--- a/src/server/api/services/memberService.ts
+++ b/src/server/api/services/memberService.ts
@@ -94,6 +94,7 @@ export const syncMemberPeersAndStatus = async (
 				where: { nwid: updatedMember.nwid, id: updatedMember.id },
 				data: updateData,
 			});
+
 			// If the member was not found in the database, add it
 			if (updateResult.count === 0) {
 				await addNetworkMember(ctx, updatedMember).catch(console.error);

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -318,6 +318,16 @@ export const authOptions: NextAuthOptions = {
 				// If the user does not exist, set user to null
 				return { ...session, user: null };
 			}
+
+			// update users lastseen in the database
+			await prisma.user.update({
+				where: {
+					id: user.id,
+				},
+				data: {
+					lastseen: new Date(),
+				},
+			});
 			session.user = { ...token } as IUser;
 			return session;
 		},


### PR DESCRIPTION
- Check if a user has been offline for more than 5 minutes, then fetch paths, peers for all network members, and update database. This operation is scheduled by a Cron task to run every 5 minutes.
- Update users lastseen in db.


Resolves #313