### PR TITLE
Set member mode indicators in table.

### DIFF
--- a/src/components/networkByIdPage/table/memberEditCell.tsx
+++ b/src/components/networkByIdPage/table/memberEditCell.tsx
@@ -137,6 +137,7 @@ const MemberEditCell = ({ nwid, central = false, organizationId }: IProp) => {
 				);
 			}
 			if (id === "ipAssignments") {
+				const { noAutoAssignIps, activeBridge } = original || null;
 				const hasRfc4193 = networkById?.network?.v6AssignMode?.rfc4193;
 				const has6plane = networkById?.network?.v6AssignMode?.["6plane"];
 
@@ -224,6 +225,22 @@ const MemberEditCell = ({ nwid, central = false, organizationId }: IProp) => {
 													/>
 												</svg>
 											</div>
+										)}
+									</div>
+									<div className="flex gap-1 pl-1">
+										{noAutoAssignIps ? (
+											<kbd title="Do Not Auto-Assign IPs" className="kbd kbd-xs">
+												AA
+											</kbd>
+										) : (
+											""
+										)}
+										{activeBridge ? (
+											<kbd title="Allow Ethernet Bridging" className="kbd kbd-xs">
+												EB
+											</kbd>
+										) : (
+											""
 										)}
 									</div>
 								</div>

--- a/src/components/organization/networkTable.tsx
+++ b/src/components/organization/networkTable.tsx
@@ -46,7 +46,7 @@ interface OrgMemberEntity extends CentralMemberEntity {
 export const OrganizationNetworkTable = ({ tableData = [] }) => {
 	// Load initial state from localStorage or set to default
 	const initialSortingState = getLocalStorageItem(LOCAL_STORAGE_KEY, [
-		{ id: "id", desc: true },
+		{ id: "nwid", desc: true },
 	]);
 
 	const router = useRouter();

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -7,7 +7,7 @@ import { throwError, type APIError } from "~/server/helpers/errorHandler";
 import { createTransporter, inviteUserTemplate, sendEmail } from "~/utils/mail";
 import ejs from "ejs";
 import { type TagsByName, type NetworkEntity } from "~/types/local/network";
-import { type CapabilitiesByName } from "~/types/local/member";
+import { MemberEntity, type CapabilitiesByName } from "~/types/local/member";
 import { type CentralNetwork } from "~/types/central/network";
 import { checkUserOrganizationRole } from "~/utils/role";
 import { Role } from "@prisma/client";
@@ -173,7 +173,7 @@ export const networkRouter = createTRPCRouter({
 					...networkFromDatabase,
 					cidr: cidrOptions,
 				},
-				members: mergedMembers,
+				members: mergedMembers as MemberEntity[],
 				zombieMembers,
 			};
 		}),

--- a/src/types/central/network.d.ts
+++ b/src/types/central/network.d.ts
@@ -85,4 +85,5 @@ export interface CentralNetwork extends NetworkBase {
 export interface FlattenCentralNetwork extends NetworkBase, Partial<NetworkConfig> {
 	cidr?: string[];
 	nwid?: string;
+	autoAssignIp?: boolean;
 }

--- a/src/types/local/network.d.ts
+++ b/src/types/local/network.d.ts
@@ -6,6 +6,7 @@ export interface NetworkEntity {
 	private?: boolean;
 	description?: string;
 	remoteTraceLevel?: number;
+	autoAssignIp?: boolean;
 	remoteTraceTarget?: null;
 	revision?: number;
 	tags?: Tag[];


### PR DESCRIPTION
If a member has "Allow Ethernet Bridging" or "Do Not Auto-Assign IPs" enabled, a marker will be visible in the member table.

![image](https://github.com/sinamics/ztnet/assets/7771916/ad51a011-2a9b-434b-8246-aceb161e149d)

Ref #373