### PR TITLE
Assign unused subnet automatically

### DIFF
--- a/src/components/networkByIdPage/ipv4Assignment.tsx
+++ b/src/components/networkByIdPage/ipv4Assignment.tsx
@@ -122,7 +122,7 @@ export const Ipv4Assignment = ({ central = false, organizationId }: IProp) => {
 	return (
 		<div>
 			{/* if  network.duplicateRoutes.length > 0 show badge */}
-			{network?.duplicateRoutes.length > 0 ? (
+			{network?.duplicateRoutes?.length > 0 ? (
 				<div role="alert" className="alert bg-base-100 mb-5">
 					<svg
 						xmlns="http://www.w3.org/2000/svg"

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -50,6 +50,7 @@ export const networkRouter = createTRPCRouter({
 			if (input.central) {
 				return await ztController.get_controller_networks(ctx, input.central);
 			}
+
 			const networks = await ctx.prisma.network.findMany({
 				where: {
 					authorId: ctx.session.user.id,
@@ -138,7 +139,7 @@ export const networkRouter = createTRPCRouter({
 			);
 
 			// Generate CIDR options for IP configuration
-			const { cidrOptions } = IPv4gen(null);
+			const { cidrOptions } = IPv4gen(null, []);
 
 			/**
 			 * Merging logic to ensure that members who only exist in local database ( added manually ) are also included in the response
@@ -540,6 +541,7 @@ export const networkRouter = createTRPCRouter({
 			// generate network params
 			const { ipAssignmentPools, routes, v4AssignMode } = IPv4gen(
 				input.updateParams.routes[0].target,
+				[],
 			);
 
 			// prepare update params

--- a/src/server/api/services/networkService.ts
+++ b/src/server/api/services/networkService.ts
@@ -59,7 +59,7 @@ export const networkProvisioningFactory = async ({ ctx, input }) => {
 
 		// Flatten the array
 		// Generate ipv4 address, cidr, start & end
-		const ipAssignmentPools = IPv4gen(null, usedIPs);
+		const ipAssignmentPools = IPv4gen(null, usedIPs, input.central);
 
 		if (!input?.name) {
 			// Generate adjective and noun word

--- a/src/server/api/services/networkService.ts
+++ b/src/server/api/services/networkService.ts
@@ -45,9 +45,18 @@ export const networkProvisioningFactory = async ({ ctx, input }) => {
 				);
 			}
 		}
+		// get used IPs from the database
+		const usedCidr = await ctx.prisma.network.findMany({
+			select: {
+				routes: true,
+			},
+		});
+		// Extract the target from the routes
+		const usedIPs = usedCidr.map((nw) => nw.routes?.map((r) => r.target));
 
+		// Flatten the array
 		// Generate ipv4 address, cidr, start & end
-		const ipAssignmentPools = IPv4gen(null);
+		const ipAssignmentPools = IPv4gen(null, usedIPs);
 
 		if (!input?.name) {
 			// Generate adjective and noun word
@@ -74,6 +83,7 @@ export const networkProvisioningFactory = async ({ ctx, input }) => {
 					create: {
 						name: newNw.name,
 						nwid: newNw.nwid,
+						routes: ipAssignmentPools.routes,
 					},
 				},
 			},

--- a/src/server/api/services/networkService.ts
+++ b/src/server/api/services/networkService.ts
@@ -47,6 +47,9 @@ export const networkProvisioningFactory = async ({ ctx, input }) => {
 		}
 		// get used IPs from the database
 		const usedCidr = await ctx.prisma.network.findMany({
+			where: {
+				authorId: ctx.session.user.id,
+			},
 			select: {
 				routes: true,
 			},

--- a/src/utils/IPv4gen.ts
+++ b/src/utils/IPv4gen.ts
@@ -23,16 +23,40 @@ const cidrOptions = [
 	"172.25.30.0/24",
 ];
 
-// const generateCidr = () => {
-// 	return cidrOptions[Math.floor(Math.random() * cidrOptions.length)];
-// };
 const generateCidr = (usedCidr: string[][]) => {
 	// Flatten the usedCidr array
 	const flattenedUsedCidr = usedCidr.flat();
 
+	// Count the frequency of each CIDR in the usedCidr array
+	const cidrFrequency: { [key: string]: number } = {};
+	for (const cidr of flattenedUsedCidr) {
+		if (cidrFrequency[cidr]) {
+			cidrFrequency[cidr]++;
+		} else {
+			cidrFrequency[cidr] = 1;
+		}
+	}
+
 	// Filter the available CIDRs
 	const availableCidr = cidrOptions.filter((cidr) => !flattenedUsedCidr.includes(cidr));
-	return availableCidr.length > 0 ? availableCidr[0] : cidrOptions[0];
+
+	// If there are available CIDRs, return the first one
+	if (availableCidr.length > 0) {
+		return availableCidr[0];
+	}
+
+	// If no available CIDRs, find the CIDR with the fewest occurrences
+	let leastUsedCidr = cidrOptions[0];
+	let minCount = Infinity;
+	for (const cidr of cidrOptions) {
+		const count = cidrFrequency[cidr] || 0;
+		if (count < minCount) {
+			minCount = count;
+			leastUsedCidr = cidr;
+		}
+	}
+
+	return leastUsedCidr;
 };
 export const IPv4gen = (CIDR: string | null, usedCidr) => {
 	const cidr = CIDR ? CIDR : generateCidr(usedCidr);

--- a/src/utils/IPv4gen.ts
+++ b/src/utils/IPv4gen.ts
@@ -23,12 +23,19 @@ const cidrOptions = [
 	"172.25.30.0/24",
 ];
 
-const generateCidr = () => {
-	return cidrOptions[Math.floor(Math.random() * cidrOptions.length)];
-};
+// const generateCidr = () => {
+// 	return cidrOptions[Math.floor(Math.random() * cidrOptions.length)];
+// };
+const generateCidr = (usedCidr: string[][]) => {
+	// Flatten the usedCidr array
+	const flattenedUsedCidr = usedCidr.flat();
 
-export const IPv4gen = (CIDR: string | null) => {
-	const cidr = CIDR ? CIDR : generateCidr();
+	// Filter the available CIDRs
+	const availableCidr = cidrOptions.filter((cidr) => !flattenedUsedCidr.includes(cidr));
+	return availableCidr.length > 0 ? availableCidr[0] : cidrOptions[0];
+};
+export const IPv4gen = (CIDR: string | null, usedCidr) => {
+	const cidr = CIDR ? CIDR : generateCidr(usedCidr);
 
 	const [start, prefix] = cidr.split("/");
 	const host32 = ((1 << (32 - parseInt(prefix))) - 1) >>> 0;

--- a/src/utils/IPv4gen.ts
+++ b/src/utils/IPv4gen.ts
@@ -23,7 +23,12 @@ const cidrOptions = [
 	"172.25.30.0/24",
 ];
 
-const generateCidr = (usedCidr: string[][]) => {
+const generateCidr = (usedCidr: string[][], getRandom = false) => {
+	// If getRandom is true, return one randomly
+	if (getRandom) {
+		return cidrOptions[Math.floor(Math.random() * cidrOptions.length)];
+	}
+
 	// Flatten the usedCidr array
 	const flattenedUsedCidr = usedCidr.flat();
 
@@ -58,8 +63,8 @@ const generateCidr = (usedCidr: string[][]) => {
 
 	return leastUsedCidr;
 };
-export const IPv4gen = (CIDR: string | null, usedCidr) => {
-	const cidr = CIDR ? CIDR : generateCidr(usedCidr);
+export const IPv4gen = (CIDR: string | null, usedCidr, getRandom = false) => {
+	const cidr = CIDR ? CIDR : generateCidr(usedCidr, getRandom);
 
 	const [start, prefix] = cidr.split("/");
 	const host32 = ((1 << (32 - parseInt(prefix))) - 1) >>> 0;

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -489,7 +489,7 @@ export const central_network_detail = async (
 			: [];
 
 		// Get available cidr options.
-		const ipAssignmentPools = IPv4gen(null);
+		const ipAssignmentPools = IPv4gen(null,[]);
 		const { cidrOptions } = ipAssignmentPools;
 		const { id: networkId, config: networkConfig, ...restData } = network;
 

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -489,7 +489,10 @@ export const central_network_detail = async (
 			: [];
 
 		// Get available cidr options.
-		const ipAssignmentPools = IPv4gen(null,[]);
+		const getRandomCidr = true;
+		const usedIps = [];
+		const ipAssignmentPools = IPv4gen(null, usedIps, getRandomCidr);
+
 		const { cidrOptions } = ipAssignmentPools;
 		const { id: networkId, config: networkConfig, ...restData } = network;
 


### PR DESCRIPTION
For each newly created network, the system will check for already used subnets and choose an unused CIDR. 
If all subnets are in use, it will select the subnet that has been used the least.