### PR TITLE
Security upgrade for docker node image

### DIFF
--- a/.devcontainer/Dockerfile.dev
+++ b/.devcontainer/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node:18-bullseye-slim
+FROM node:22.1-bookworm-slim
 
 ENV NODE_ENV development
 RUN apt update && apt install -y git curl sudo postgresql-client procps nano

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODEJS_IMAGE=node:18-bullseye-slim
+ARG NODEJS_IMAGE=node:22.1-bookworm-slim
 FROM --platform=$BUILDPLATFORM $NODEJS_IMAGE AS base
 
 # Install dependencies only when needed

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,7 @@
 
 generator client {
   provider      = "prisma-client-js"
-  //binaryTargets = ["native", "debian-openssl-1.1.x", "linux-arm64-openssl-1.1.x"]
-  binaryTargets = ["native", "debian-openssl-1.1.x" ,"debian-openssl-3.0.x", "linux-arm64-openssl-1.1.x"]
+  binaryTargets = ["native", "debian-openssl-3.0.x", "linux-arm64-openssl-3.0.x"]
 }
 
 datasource db {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,7 +3,8 @@
 
 generator client {
   provider      = "prisma-client-js"
-  binaryTargets = ["native", "debian-openssl-1.1.x", "linux-arm64-openssl-1.1.x"]
+  //binaryTargets = ["native", "debian-openssl-1.1.x", "linux-arm64-openssl-1.1.x"]
+  binaryTargets = ["native", "debian-openssl-1.1.x" ,"debian-openssl-3.0.x", "linux-arm64-openssl-1.1.x"]
 }
 
 datasource db {


### PR DESCRIPTION
Following a Snyk scan of the repo, vulnerabilities in the debian node docker image.

Bumped the version to node:22.1-bookworm-slim.

The schema.prisma file has been updated to include "debian-openssl-3.0.x" in the binaryTargets configuration. This ensures that the Prisma Client generates the necessary binaries for the correct OpenSSL version following the image upgrade.

Tested deployment on Debian 11 with Docker Engine - Community Version 26.0.1, API version 1.45
