### PR TITLE
Removed "version" tag in docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   # db
   postgres:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.1"
 services:
   postgres:
     image: postgres:15.2-alpine

--- a/docs/docs/Installation/docker-compose.md
+++ b/docs/docs/Installation/docker-compose.md
@@ -39,7 +39,6 @@ Change the **NEXTAUTH_URL** environment variable to the canonical URL or IP of y
 :::
 
 ```yml title="Create a docker-compose.yml file and populate it as follows:"
-version: "3.1"
 services:
   postgres:
     image: postgres:15.2-alpine


### PR DESCRIPTION
The version tag is now obsolete.
https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements