### PR TITLE
Redirect to new network upon creation

### DIFF
--- a/src/components/networkPage/centralNetworkTable.tsx
+++ b/src/components/networkPage/centralNetworkTable.tsx
@@ -42,7 +42,7 @@ const LOCAL_STORAGE_KEY = "centralNetworkTableSorting";
 export const CentralNetworkTable = ({ tableData = [] }) => {
 	// Load initial state from localStorage or set to default
 	const initialSortingState = getLocalStorageItem(LOCAL_STORAGE_KEY, [
-		{ id: "id", desc: true },
+		{ id: "nwid", desc: true },
 	]);
 
 	const router = useRouter();

--- a/src/pages/central/index.tsx
+++ b/src/pages/central/index.tsx
@@ -8,6 +8,7 @@ import { globalSiteTitle } from "~/utils/global";
 import { useTranslations } from "next-intl";
 import { getServerSideProps } from "~/server/getServerSideProps";
 import useOrganizationWebsocket from "~/hooks/useOrganizationWebsocket";
+import { useRouter } from "next/router";
 
 const title = `${globalSiteTitle} - Zerotier Central`;
 
@@ -30,6 +31,7 @@ interface IProps {
 const CentralNetworks: NextPageWithLayout = ({ orgIds }: IProps) => {
 	const b = useTranslations("commonButtons");
 	const t = useTranslations("networks");
+	const router = useRouter();
 	const {
 		data: centralNetworks,
 		isLoading,
@@ -42,7 +44,17 @@ const CentralNetworks: NextPageWithLayout = ({ orgIds }: IProps) => {
 
 	const { mutate: createNetwork } = api.network.createNetwork.useMutation();
 	const addNewNetwork = () => {
-		createNetwork({ central: true }, { onSuccess: () => void refetch() });
+		createNetwork(
+			{ central: true },
+			{
+				onSuccess: (createdNetwork) => {
+					if (createdNetwork?.nwid) {
+						return void router.push(`/central/${createdNetwork.nwid}`);
+					}
+					void refetch();
+				},
+			},
+		);
 	};
 
 	if (isLoading) {

--- a/src/pages/network/index.tsx
+++ b/src/pages/network/index.tsx
@@ -15,6 +15,7 @@ import {
 } from "~/hooks/useTrpcApiHandler";
 import Link from "next/link";
 import { User } from "@prisma/client";
+import { useRouter } from "next/router";
 
 type OrganizationId = {
 	id: string;
@@ -29,6 +30,7 @@ const title = `${globalSiteTitle} - Local Controller`;
 const Networks: NextPageWithLayout = ({ orgIds, user }: IProps) => {
 	const b = useTranslations("commonButtons");
 	const t = useTranslations("networks");
+	const router = useRouter();
 
 	const handleApiError = useTrpcApiErrorHandler();
 	const handleApiSuccess = useTrpcApiSuccessHandler();
@@ -56,7 +58,17 @@ const Networks: NextPageWithLayout = ({ orgIds, user }: IProps) => {
 	});
 
 	const addNewNetwork = () => {
-		createNetwork({ central: false }, { onSuccess: () => void refetch() });
+		createNetwork(
+			{ central: false },
+			{
+				onSuccess: (createdNetwork) => {
+					if (createdNetwork?.id) {
+						return void router.push(`/network/${createdNetwork.id}`);
+					}
+					void refetch();
+				},
+			},
+		);
 	};
 
 	if (isLoading) {

--- a/src/pages/organization/[orgid].tsx
+++ b/src/pages/organization/[orgid].tsx
@@ -55,10 +55,14 @@ const OrganizationById = ({ user, orgIds }) => {
 	const { data: orgUsers } = api.org.getOrgUsers.useQuery({
 		organizationId,
 	});
-
 	const { mutate: createNetwork } = api.org.createOrgNetwork.useMutation({
 		onError: handleApiError,
-		onSuccess: handleApiSuccess({ actions: [refecthOrg] }),
+		onSuccess: (createdNetwork) => {
+			if (createdNetwork?.id) {
+				return void push(`/organization/${organizationId}/${createdNetwork.id}`);
+			}
+			void handleApiSuccess({ actions: [refecthOrg] });
+		},
 	});
 
 	useEffect(() => {

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -1121,7 +1121,7 @@ export const networkRouter = createTRPCRouter({
 		)
 		.mutation(async (props) => {
 			// abstracted due to pages/api/v1/network/index.ts
-			await networkProvisioningFactory(props);
+			return await networkProvisioningFactory(props);
 		}),
 	setFlowRule: protectedProcedure
 		.input(


### PR DESCRIPTION
When user creates a new network, the application will automatically redirect them to the newly created network's page upon successful creation.

Resolves #437