### PR TITLE
Bugfix slow network load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
 				"next-intl": "3.1.4",
 				"next-themes": "^0.2.1",
 				"nodemailer": "^6.9.9",
+				"p-limit": "^6.1.0",
 				"pug": "^3.0.3",
 				"qrcode.react": "^3.1.0",
 				"react": "18.2.0",
@@ -5619,6 +5620,33 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-changed-files/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-changed-files/node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/jest-circus": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
@@ -5662,6 +5690,21 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/jest-circus/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/jest-circus/node_modules/pretty-format": {
 			"version": "29.7.0",
 			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5681,6 +5724,18 @@
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
 			"integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
 			"dev": true
+		},
+		"node_modules/jest-circus/node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/jest-cli": {
 			"version": "29.7.0",
@@ -6364,6 +6419,33 @@
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/jest-runner/node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/jest-runtime": {
@@ -7529,15 +7611,14 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"node_modules/p-limit": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-			"dev": true,
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-6.1.0.tgz",
+			"integrity": "sha512-H0jc0q1vOzlEk0TqAKXKZxdl7kX3OFUzCnNVUnq5Pc3DGo0kpeaMuPqxQn235HibwBEb0/pm9dgKTjXy66fBkg==",
 			"dependencies": {
-				"yocto-queue": "^0.1.0"
+				"yocto-queue": "^1.1.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=18"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -9865,12 +9946,11 @@
 			}
 		},
 		"node_modules/yocto-queue": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-			"dev": true,
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.1.1.tgz",
+			"integrity": "sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==",
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
 		"next-intl": "3.1.4",
 		"next-themes": "^0.2.1",
 		"nodemailer": "^6.9.9",
+		"p-limit": "^6.1.0",
 		"pug": "^3.0.3",
 		"qrcode.react": "^3.1.0",
 		"react": "18.2.0",

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -75,6 +75,7 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.query(async ({ ctx, input }) => {
+			console.time("Total time for loading Networks Details");
 			if (input.central) {
 				return await ztController.central_network_detail(ctx, input.nwid, input.central);
 			}
@@ -223,6 +224,8 @@ export const networkRouter = createTRPCRouter({
 
 			// Convert the map back to an array of merged members
 			const mergedMembers = [...mergedMembersMap.values()];
+
+			console.timeEnd("Total time for loading Networks Details");
 			// Construct the final response object
 			return {
 				network: {

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -245,6 +245,7 @@ export const networkRouter = createTRPCRouter({
 				};
 			} catch (error) {
 				console.error(error);
+				return throwError("Failed to get network details! See logs for more details.");
 			}
 		}),
 	deleteNetwork: protectedProcedure

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -10,7 +10,7 @@ import { type TagsByName, type NetworkEntity, RoutesEntity } from "~/types/local
 import { MemberEntity, type CapabilitiesByName } from "~/types/local/member";
 import { type CentralNetwork } from "~/types/central/network";
 import { checkUserOrganizationRole } from "~/utils/role";
-import { Prisma, Role } from "@prisma/client";
+import { Role } from "@prisma/client";
 import { HookType, NetworkConfigChanged, NetworkDeleted } from "~/types/webhooks";
 import { sendWebhook } from "~/utils/webhook";
 import { fetchZombieMembers, syncMemberPeersAndStatus } from "../services/memberService";
@@ -193,23 +193,23 @@ export const networkRouter = createTRPCRouter({
 			}
 
 			// check if there are any other networks with the same routes.
-			let duplicateRoutes: DuplicateRoutes[] = [];
-			if (targetIPs.length > 0) {
-				duplicateRoutes = await ctx.prisma.$queryRaw<DuplicateRoutes[]>`
-							SELECT "authorId", "routes", "name", "nwid"
-							FROM "network"
-							WHERE "authorId" = ${ctx.session.user.id}
-									AND EXISTS (
-											SELECT 1
-											FROM jsonb_array_elements("routes") as route
-											WHERE route->>'target' IN (${Prisma.join(targetIPs)})
-									)
-									AND "nwid" != ${input.nwid};
-					`;
-			} else {
-				// Handle the case when targetIPs is empty
-				duplicateRoutes = [];
-			}
+			const duplicateRoutes: DuplicateRoutes[] = [];
+			// if (targetIPs.length > 0) {
+			// 	duplicateRoutes = await ctx.prisma.$queryRaw<DuplicateRoutes[]>`
+			// 				SELECT "authorId", "routes", "name", "nwid"
+			// 				FROM "network"
+			// 				WHERE "authorId" = ${ctx.session.user.id}
+			// 						AND EXISTS (
+			// 								SELECT 1
+			// 								FROM jsonb_array_elements("routes") as route
+			// 								WHERE route->>'target' IN (${Prisma.join(targetIPs)})
+			// 						)
+			// 						AND "nwid" != ${input.nwid};
+			// 		`;
+			// } else {
+			// 	// Handle the case when targetIPs is empty
+			// 	duplicateRoutes = [];
+			// }
 
 			// Extract duplicated IPs
 			const duplicatedIPs = duplicateRoutes.flatMap((network) =>

--- a/src/server/api/services/memberService.ts
+++ b/src/server/api/services/memberService.ts
@@ -8,36 +8,6 @@ import { HookType, MemberJoined } from "~/types/webhooks";
 import { throwError } from "~/server/helpers/errorHandler";
 import { network_members } from "@prisma/client";
 
-// create a dummy array of 30 member
-// export const dummyMembers = Array.from({ length: 10 }, (_, i) => ({
-// 	activeBridge: false,
-// 	address: "efcc1b0947",
-// 	authenticationExpiryTime: 0,
-// 	authorized: true,
-// 	capabilities: [],
-// 	creationTime: 1719608117618,
-// 	id: "efcc1b0947",
-// 	identity:
-// 		"efcc1b0947:0:0152e4bbdf517c0218ff096db3195f65b7f66cb544d6506cb13fe01f9851212652f2cabe6133bd0e83e0c2930c7db23a2e14574782256e94e831711d04c48979",
-// 	ipAssignments: [],
-// 	lastAuthorizedCredential: null,
-// 	lastAuthorizedCredentialType: "api",
-// 	lastAuthorizedTime: 1720759395643,
-// 	lastDeauthorizedTime: 0,
-// 	noAutoAssignIps: false,
-// 	nwid: "fc6b977f183f6a65",
-// 	objtype: "member",
-// 	remoteTraceLevel: 0,
-// 	remoteTraceTarget: null,
-// 	revision: 2,
-// 	ssoExempt: false,
-// 	tags: [],
-// 	vMajor: -1,
-// 	vMinor: -1,
-// 	vProto: -1,
-// 	vRev: -1,
-// }));
-
 /**
  * syncMemberPeersAndStatus
  * Synchronizes the peers and connection status of the given members.

--- a/src/types/local/member.d.ts
+++ b/src/types/local/member.d.ts
@@ -67,22 +67,16 @@ interface CentralMemberConfig {
 }
 
 export interface Peers {
-	active: boolean;
 	address: string;
 	isBonded: boolean;
 	latency: number;
-	lastReceive: number;
-	lastSend: number;
-	localSocket?: number;
 	paths?: Paths[];
 	role: string;
 	version: string;
-	physicalAddress: string;
+	physicalAddress?: string;
 	versionMajor: number;
 	versionMinor: number;
 	versionRev: number;
-	preferred: boolean;
-	trustedPathId: number;
 }
 
 export interface Paths {

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -625,7 +625,7 @@ export const member_details = async (
 
 // Get all peers
 // https://docs.zerotier.com/service/v1/#operation/getPeers
-export const peers = async (ctx: UserContext): Promise<ZTControllerGetPeer> => {
+export const peers = async (ctx: UserContext): Promise<ZTControllerGetPeer[]> => {
 	// get headers based on local or central api
 	const { localControllerUrl } = await getOptions(ctx, false);
 
@@ -635,7 +635,7 @@ export const peers = async (ctx: UserContext): Promise<ZTControllerGetPeer> => {
 
 	try {
 		const response: AxiosResponse = await axios.get(addr, { headers });
-		return response.data as ZTControllerGetPeer;
+		return response.data as ZTControllerGetPeer[];
 	} catch (error) {
 		const message = `${error} (peers)`;
 		throw new APIError(message, error as AxiosError);


### PR DESCRIPTION
Previously, the code looped over all members and fetched the peer for each one individually, causing the ZeroTier API to become unresponsive with many members. Now, all peers are fetched in one go and then filtered by member id, improving performance.

resolves #435