### PR TITLE
Set user device cookie maxAge to 1 year

### DIFF
--- a/src/components/auth/userDevices.tsx
+++ b/src/components/auth/userDevices.tsx
@@ -75,6 +75,16 @@ const ListUserDevices: React.FC<{ devices: UserDevice[] }> = ({ devices }) => {
 			},
 		});
 
+	const invalidateUserDevice = async () => {
+		try {
+			await fetch("/api/auth/user/invalidateUserDevice", {
+				method: "POST",
+			});
+		} catch (error) {
+			console.error("Error deleting device cookie:", error);
+		}
+	};
+
 	const currentDeviceId = session?.user?.deviceId;
 
 	const isCurrentDevice = (device: UserDevice) => {
@@ -119,7 +129,7 @@ const ListUserDevices: React.FC<{ devices: UserDevice[] }> = ({ devices }) => {
 								className="btn btn-sm btn-primary"
 								onClick={() => {
 									deleteUserDevice({ deviceId: device.deviceId });
-									isCurrentDevice(device) && signOut();
+									isCurrentDevice(device) && signOut().then(() => invalidateUserDevice());
 								}}
 							>
 								{t("userSettings.account.userDevices.logout")}

--- a/src/pages/api/auth/user/invalidateUserDevice.ts
+++ b/src/pages/api/auth/user/invalidateUserDevice.ts
@@ -1,0 +1,13 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { deleteDeviceCookie } from "~/utils/devices";
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+	if (req.method === "POST") {
+		// Set the cookie with an expiration date in the past
+		deleteDeviceCookie(res);
+
+		res.status(200).json({ message: "Device cookie deleted" });
+	} else {
+		res.status(405).end(`Method ${req.method} Not Allowed`);
+	}
+}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -281,7 +281,7 @@ export const getAuthOptions = (
 		 * @see https://next-auth.js.org/configuration/callbacks#sign-in-callback
 		 */
 		signIn: signInCallback(req, res),
-		jwt: jwtCallback(),
+		jwt: jwtCallback(res),
 		session: sessionCallback(req),
 		redirect({ url, baseUrl }) {
 			// Allows relative callback URLs

--- a/src/server/callbacks/jwt.ts
+++ b/src/server/callbacks/jwt.ts
@@ -1,9 +1,8 @@
 import { prisma } from "../db";
+import { deleteDeviceCookie } from "~/utils/devices";
 
-export function jwtCallback() {
+export function jwtCallback(res) {
 	return async function jwt({ token, user, trigger, account, session, profile }) {
-		// console.log(user);
-
 		if (trigger === "update") {
 			if (session.update) {
 				const updateObject: Record<string, string | Date> = {};
@@ -78,8 +77,12 @@ export function jwtCallback() {
 				});
 
 				if (!userDevice) {
+					// Delete the device cookie
+					deleteDeviceCookie(res);
+
 					// Device doesn't exist, invalidate the deviceId in the token
 					token.deviceId = undefined;
+
 					return token;
 				}
 

--- a/src/utils/devices.ts
+++ b/src/utils/devices.ts
@@ -1,5 +1,9 @@
+import { serialize } from "cookie";
+import { GetServerSidePropsContext } from "next";
 import UAParser from "ua-parser-js";
 import { prisma } from "~/server/db";
+
+export const DEVICE_SALT_COOKIE_NAME = "next-auth.did-token";
 export interface ParsedUA {
 	deviceType: string;
 	browser: string;
@@ -51,3 +55,52 @@ export async function validateDeviceId(
 
 	return true;
 }
+
+/**
+ * Creates a user device cookie.
+ *
+ * @param res - The server response object.
+ * @param deviceId - The device ID.
+ */
+export const createDeviceCookie = (
+	res: GetServerSidePropsContext["res"],
+	deviceId: string,
+) => {
+	try {
+		res.setHeader("Set-Cookie", [
+			serialize(DEVICE_SALT_COOKIE_NAME, deviceId, {
+				httpOnly: true,
+				secure: false,
+				sameSite: "lax",
+				maxAge: 1 * 365 * 24 * 60 * 60, // 1 year
+				expires: new Date(Date.now() + 1 * 365 * 24 * 60 * 60 * 1000), // 1 year
+				path: "/",
+			}),
+		]);
+	} catch (error) {
+		console.error("Error creating device cookie:", error);
+	}
+};
+
+/**
+ * Deletes or invalidates the user device cookie.
+ *
+ * @param res - The server response object.
+ * @param deviceId - The ID of the device to delete the cookie for.
+ */
+export const deleteDeviceCookie = (res: GetServerSidePropsContext["res"]) => {
+	try {
+		res.setHeader("Set-Cookie", [
+			serialize(DEVICE_SALT_COOKIE_NAME, "", {
+				httpOnly: true,
+				secure: false,
+				sameSite: "lax",
+				maxAge: -1,
+				expires: new Date(0),
+				path: "/",
+			}),
+		]);
+	} catch (error) {
+		console.error("Error deleting device cookie:", error);
+	}
+};


### PR DESCRIPTION
User device maxAge was previously set to `session`, as i belived this was the same as never, but session will terminate when browser is closed. 

Updated device cookie to have maxAge of 1 year.
![image](https://github.com/user-attachments/assets/f67fe6ac-7cee-4242-86a2-ad0628f10580)

Cookie expire date is not dynamically updated, so the user device will be invalidated in 1 year. This could be improved by udpate the cookie when user interact with ztnet. 

Related #526