### PR TITLE
Allow for non-standard Postgres port to be used

### DIFF
--- a/init-db.sh
+++ b/init-db.sh
@@ -45,7 +45,7 @@ function apply_path {
 
 # apply_path
 
-until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$POSTGRES_HOST" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\q'; do
+until PGPASSWORD=$POSTGRES_PASSWORD psql -h "$POSTGRES_HOST" -p "$POSTGRES_PORT" -U "$POSTGRES_USER" -d "$POSTGRES_DB" -c '\q'; do
   echo "Postgres is unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
Hi,
If a custom port is set (external Postgres server), the init-db.sh script will fail because the custom port is not used in the psql command.