### PR TITLE
Return node data from controller as first priority.

### DIFF
--- a/src/components/networkByIdPage/table/memberEditCell.tsx
+++ b/src/components/networkByIdPage/table/memberEditCell.tsx
@@ -37,16 +37,6 @@ const MemberEditCell = ({ nwid, central = false, organizationId }: IProp) => {
 		);
 
 	const { data: me } = api.auth.me.useQuery();
-	const { mutate: updateMemberDatabaseOnly } =
-		api.networkMember.UpdateDatabaseOnly.useMutation({
-			onError: handleApiError,
-			onSuccess: handleApiSuccess({
-				actions: [refetchNetworkById],
-				toastMessage: t(
-					"networkById.networkMembersTable.toastMessages.memberNameUpdated",
-				),
-			}),
-		});
 
 	const { mutate: updateMember } = api.networkMember.Update.useMutation({
 		onError: handleApiError,
@@ -86,14 +76,12 @@ const MemberEditCell = ({ nwid, central = false, organizationId }: IProp) => {
 
 			const submitName = (e: React.MouseEvent<HTMLButtonElement>) => {
 				e.preventDefault();
-				updateMemberDatabaseOnly({
-					nwid,
-					id: original.id,
-					central,
+				updateMember({
+					updateParams: { name: value as string },
+					memberId: original.id,
 					organizationId,
-					updateParams: {
-						name: value as string,
-					},
+					nwid,
+					central,
 				});
 
 				inputRef.current?.blur();

--- a/src/pages/api/__tests__/v1/network/network.test.ts
+++ b/src/pages/api/__tests__/v1/network/network.test.ts
@@ -8,7 +8,7 @@ describe("/api/createNetwork", () => {
 			status: jest.fn().mockReturnThis(),
 			end: jest.fn(),
 			json: jest.fn().mockReturnThis(),
-			setHeader: jest.fn(), // Mock `setHeader` rate limiter uses it
+			setHeader: jest.fn(),
 		} as unknown as NextApiResponse;
 
 		await apiNetworkHandler(req, res);

--- a/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
+++ b/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
@@ -33,6 +33,7 @@ jest.mock("~/utils/ztApi", () => {
 	return {
 		...originalModule,
 		member_update: jest.fn(),
+		member_details: jest.fn(),
 	};
 });
 describe("Update Network Members", () => {
@@ -109,6 +110,8 @@ describe("Update Network Members", () => {
 		prisma.aPIToken.findUnique = jest.fn().mockResolvedValue({
 			expiresAt: new Date(),
 		});
+
+		(ztController.member_details as jest.Mock).mockResolvedValue({});
 
 		const req = {
 			method: "POST",

--- a/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
+++ b/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
@@ -111,7 +111,7 @@ describe("Update Network Members", () => {
 			expiresAt: new Date(),
 		});
 
-		(ztController.member_details as jest.Mock).mockResolvedValue({});
+		(ztController.member_details as jest.Mock).mockResolvedValue([]);
 
 		const req = {
 			method: "POST",

--- a/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
+++ b/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
@@ -106,6 +106,11 @@ describe("Update Network Members", () => {
 			networkMembers: [{ id: "memberId" }],
 		});
 
+		prisma.network_members.findUnique = jest.fn().mockResolvedValue({
+			id: "memberId",
+			authorized: false,
+		});
+
 		// mock the token
 		prisma.aPIToken.findUnique = jest.fn().mockResolvedValue({
 			expiresAt: new Date(),

--- a/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
@@ -169,6 +169,7 @@ const POST_updateNetworkMember = SecuredPrivateApiRoute(
 
 			return res.status(200).json(mergedMember);
 		} catch (cause) {
+			console.error(cause);
 			return handleApiErrors(cause, res);
 		}
 	},

--- a/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
@@ -157,7 +157,6 @@ const POST_updateNetworkMember = SecuredPrivateApiRoute(
 				// @ts-expect-error
 				ztController.member_details(ctx, networkId, memberId, false),
 			]);
-
 			if (!controllerMember) {
 				return res.status(404).json({ error: "Member not found in controller" });
 			}

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -135,7 +135,7 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 								where: {
 									id_nwid: {
 										id: memberId,
-										nwid: networkId, // this should be the value of `nwid` you are looking for
+										nwid: networkId,
 									},
 								},
 								data: {
@@ -225,6 +225,16 @@ export const GET_orgNetworkMemberById = SecuredOrganizationApiRoute(
 			const validatedContext = HandlerContextSchema.parse(context);
 			const { networkId, memberId, ctx } = validatedContext;
 
+			const controllerMember = await ztController.local_network_detail(
+				// @ts-expect-error: fake request object
+				ctx,
+				networkId,
+				false,
+			);
+
+			const findControllermemberById = controllerMember.members.find(
+				(member) => member.id === memberId,
+			);
 			// @ts-expect-error
 			const caller = appRouter.createCaller(ctx);
 			const networkAndMembers = await caller.networkMember.getMemberById({
@@ -232,7 +242,7 @@ export const GET_orgNetworkMemberById = SecuredOrganizationApiRoute(
 				id: memberId,
 			});
 
-			return res.status(200).json(networkAndMembers);
+			return res.status(200).json({ ...networkAndMembers, ...findControllermemberById });
 		} catch (cause) {
 			return handleApiErrors(cause, res);
 		}

--- a/src/server/api/__tests__/networkMembers/updateDatabaseOnly.test.ts
+++ b/src/server/api/__tests__/networkMembers/updateDatabaseOnly.test.ts
@@ -68,7 +68,7 @@ test("updateDatabaseOnly test", async () => {
 					where: {
 						id_nwid: {
 							id: input.id,
-							nwid: input.nwid, // this should be the value of `nwid` you are looking for
+							nwid: input.nwid,
 						},
 					},
 					data: {

--- a/src/server/api/__tests__/networkMembers/updateDatabaseOnly.test.ts
+++ b/src/server/api/__tests__/networkMembers/updateDatabaseOnly.test.ts
@@ -42,7 +42,6 @@ test("updateDatabaseOnly test", async () => {
 		id: "12234",
 		updateParams: {
 			deleted: false,
-			name: "test name",
 		},
 	};
 
@@ -52,6 +51,7 @@ test("updateDatabaseOnly test", async () => {
 		wss: null,
 		res: null,
 	});
+
 	// @ts-expect-error -- awaiting fix:
 	prisma.network.update.mockResolvedValue(mockOutput);
 

--- a/src/server/api/routers/memberRouter.ts
+++ b/src/server/api/routers/memberRouter.ts
@@ -51,7 +51,7 @@ export const networkMemberRouter = createTRPCRouter({
 			const dbMember = await ctx.prisma.network_members.findFirst({
 				where: {
 					id: input.id,
-					nwid: input.nwid, // this should be the value of `nwid` you are looking for
+					nwid: input.nwid,
 				},
 			});
 			return {

--- a/src/server/api/services/memberService.ts
+++ b/src/server/api/services/memberService.ts
@@ -40,10 +40,6 @@ export const syncMemberPeersAndStatus = async (
 			const activePreferredPath = findActivePreferredPeerPath(peers);
 			const { physicalAddress, ...restOfDbMembers } = dbMember || {};
 
-			// remove name from ztmember.
-			// !TODO: We dont update the member name from the controller, dont know if we should.
-			Reflect.deleteProperty(ztMember, "name");
-
 			// Merge the data from the database with the data from Controller
 			const updatedMember = {
 				...restOfDbMembers,

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -618,7 +618,7 @@ export const member_details = async (
 
 		return await getData<MemberEntity>(addr, headers);
 	} catch (error) {
-		const message = `${error} (member_details)`;
+		const message = "Member not found!";
 		throw new APIError(message, error as AxiosError);
 	}
 };


### PR DESCRIPTION
When a new node joins a network, it won't appear in the database until a user opens the network or the background task processes network members.
Previously, when accessing a member API endpoint, the data was fetched only from the database.

Changed the API endpoints to return member data from the controller as first priority, if data exist in db this will be merged into the same response.

Resolves #539