### PR TITLE
Don't send auth when both user and pass are empty

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - .:/workspaces:cached
     environment:
-      NEXTAUTH_URL: "http://10.0.0.217:3000" # Update this to the URL of your dev environment
+      NEXTAUTH_URL: "${NEXTAUTH_URL:-http://10.0.0.217:3000}"
     networks:
       - app-network
     depends_on:

--- a/src/utils/mail.ts
+++ b/src/utils/mail.ts
@@ -277,10 +277,13 @@ export async function createTransporter() {
 		host: globalOptions.smtpHost,
 		port: globalOptions.smtpPort,
 		secure: globalOptions.smtpUseSSL,
-		auth: {
-			user: globalOptions.smtpUsername,
-			pass: globalOptions.smtpPassword,
-		},
+		auth:
+			globalOptions.smtpUsername || globalOptions.smtpPassword
+				? {
+						user: globalOptions.smtpUsername,
+						pass: globalOptions.smtpPassword,
+				  }
+				: undefined,
 		tls: {
 			rejectUnauthorized: true,
 			minVersion: "TLSv1.2",


### PR DESCRIPTION
Don't send auth when both user and pass are empty.

When using an SMTP relay (such as [Google's SMTP Relay](https://support.google.com/a/answer/2956491?hl=en), `PLAIN` auth is still sent by nodemailer even if the user/pass are empty.

This PR changes the logic to only include the fields when one of the fields has data, otherwise it should be undefined.