### PR TITLE
Improved smtp mail handler

### DIFF
--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "Mail SMTP",
 			"smtpHost": "SMTP Host",
 			"smtpPort": "SMTP Port",
+			"smtpRequireTLS": "Verify SSL Certificate",
+			"smtpRequireTLSDescription": "Enforce valid SSL/TLS certificates. Disable only if using self-signed certificates.",
 			"senderEmail": "Sender Email",
 			"mailPlaceholder": "mail@example.com",
 			"username": "Username",

--- a/src/locales/es/common.json
+++ b/src/locales/es/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "Mail SMTP",
 			"smtpHost": "Host SMTP",
 			"smtpPort": "Puerto SMTP",
+			"smtpRequireTLS": "Verificar certificado SSL",
+			"smtpRequireTLSDescription": "Exigir certificados SSL/TLS válidos. Desactivar solo si usa certificados autofirmados.",
 			"senderEmail": "Correo electrónico del remitente",
 			"mailPlaceholder": "correo@ejemplo.com",
 			"username": "Nombre de usuario",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "Mail SMTP",
 			"smtpHost": "Hôte SMTP",
 			"smtpPort": "Port SMTP",
+			"smtpRequireTLS": "Vérifier le certificat SSL",
+			"smtpRequireTLSDescription": "Exiger des certificats SSL/TLS valides. Désactiver uniquement si vous utilisez des certificats auto-signés.",
 			"senderEmail": "E-mail de l'expéditeur",
 			"mailPlaceholder": "mail@exemple.com",
 			"username": "Nom d'utilisateur",

--- a/src/locales/no/common.json
+++ b/src/locales/no/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "Mail SMTP",
 			"smtpHost": "SMTP-vert",
 			"smtpPort": "SMTP-port",
+			"smtpRequireTLS": "Verifiser SSL-sertifikat",
+			"smtpRequireTLSDescription": "Krev gyldige SSL/TLS-sertifikater. Deaktiver kun ved bruk av selvsignerte sertifikater.",
 			"senderEmail": "Avsenders e-post",
 			"mailPlaceholder": "post@eksempel.com",
 			"username": "Brukernavn",

--- a/src/locales/pl/common.json
+++ b/src/locales/pl/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "Ustawienia serwera SMTP",
 			"smtpHost": "Serwer SMTP",
 			"smtpPort": "Port SMTP",
+			"smtpRequireTLS": "Weryfikuj certyfikat SSL",
+			"smtpRequireTLSDescription": "Wymagaj ważnych certyfikatów SSL/TLS. Wyłącz tylko w przypadku certyfikatów samopodpisanych.",
 			"senderEmail": "E-mail nadawcy",
 			"mailPlaceholder": "imie@twojadomena.pl",
 			"username": "Nazwa użytkownika",

--- a/src/locales/ru/common.json
+++ b/src/locales/ru/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "Почтовый SMTP",
 			"smtpHost": "SMTP-хост",
 			"smtpPort": "SMTP-порт",
+			"smtpRequireTLS": "Проверять SSL-сертификат",
+			"smtpRequireTLSDescription": "Требовать действительные SSL/TLS сертификаты. Отключите только при использовании самоподписанных сертификатов.",
 			"senderEmail": "Email отправителя",
 			"mailPlaceholder": "mail@example.com",
 			"username": "Имя пользователя",

--- a/src/locales/zh-tw/common.json
+++ b/src/locales/zh-tw/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "郵件SMTP",
 			"smtpHost": "SMTP主機",
 			"smtpPort": "SMTP端口",
+			"smtpRequireTLS": "驗證SSL憑證",
+			"smtpRequireTLSDescription": "強制要求有效的SSL/TLS憑證。僅在使用自行簽署憑證時停用。",
 			"senderEmail": "寄件人電子郵件",
 			"mailPlaceholder": "mail@example.com",
 			"username": "使用者名稱",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -449,6 +449,8 @@
 			"mailSMTP": "邮件SMTP",
 			"smtpHost": "SMTP主机",
 			"smtpPort": "SMTP端口",
+			"smtpRequireTLS": "验证SSL证书",
+			"smtpRequireTLSDescription": "强制要求有效的SSL/TLS证书。仅在使用自签名证书时禁用。",
 			"senderEmail": "发件人电子邮件",
 			"mailPlaceholder": "mail@example.com",
 			"username": "用户名",

--- a/src/pages/admin/mail/index.tsx
+++ b/src/pages/admin/mail/index.tsx
@@ -149,7 +149,7 @@ const Mail = () => {
 					submitHandler={(params) => inputHandler(params)}
 				/>
 
-				<div className="flex items-center justify-between pb-10">
+				<div className="flex items-center justify-between">
 					<p className="font-medium">{t("mail.useSSL")}</p>
 					<input
 						type="checkbox"
@@ -157,6 +157,20 @@ const Mail = () => {
 						className="checkbox-primary checkbox checkbox-sm"
 						onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
 							void inputHandler({ smtpUseSSL: e.target.checked });
+						}}
+					/>
+				</div>
+				<div className="flex items-center justify-between pb-10">
+					<div>
+						<p className="font-medium">{t("mail.smtpRequireTLS")}</p>
+						<p className="text-gray-500">{t("mail.smtpRequireTLSDescription")}</p>
+					</div>
+					<input
+						type="checkbox"
+						checked={options?.smtpRequireTLS || false}
+						className="checkbox-primary checkbox checkbox-sm"
+						onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+							void inputHandler({ smtpRequireTLS: e.target.checked });
 						}}
 					/>
 				</div>

--- a/src/utils/mail.ts
+++ b/src/utils/mail.ts
@@ -165,7 +165,14 @@ export async function sendMailWithTemplate(
 		html: parsedTemplate.body,
 	};
 
-	await sendEmail(transporter, mailOptions);
+	// Run SMTP operation in background
+	setImmediate(async () => {
+		try {
+			await sendEmail(transporter, mailOptions);
+		} catch (error) {
+			console.error("Email sending failed:", error);
+		}
+	});
 }
 
 /**

--- a/src/utils/mail.ts
+++ b/src/utils/mail.ts
@@ -292,7 +292,7 @@ export async function createTransporter() {
 				  }
 				: undefined,
 		tls: {
-			rejectUnauthorized: true,
+			rejectUnauthorized: globalOptions.smtpRequireTLS,
 			minVersion: "TLSv1.2",
 		},
 	} as TransportOptions);


### PR DESCRIPTION
This will run the smtp handler in the background and not block the main thread in case of errors.
Added option for users to set rejectUnauthorized "Verify SSL Certificate" from the web ui. it was previsouly hardcoded true.

Resolves #565