### PR TITLE
Optimize network list loading performance by using stored authorization status

### DIFF
--- a/prisma/migrations/20250415055909_member_authorized/migration.sql
+++ b/prisma/migrations/20250415055909_member_authorized/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "network_members" ADD COLUMN     "authorized" BOOLEAN DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,7 @@ model network_members {
   nwid_ref        network                 @relation(fields: [nwid], references: [nwid], onDelete: Cascade)
   nwid            String
   lastSeen        DateTime?
+  authorized      Boolean?                @default(false)
   physicalAddress String?
   online          Boolean?                @default(false)
   deleted         Boolean?                @default(false)

--- a/src/pages/api/__tests__/auth/two-factor/setup.test.tsx
+++ b/src/pages/api/__tests__/auth/two-factor/setup.test.tsx
@@ -1,4 +1,4 @@
-import { NextApiRequest, NextApiResponse } from "next";
+import type { NextApiRequest, NextApiResponse } from "next";
 import handler from "~/pages/api/auth/two-factor/totp/setup";
 import { prisma } from "~/server/db";
 import { getServerSession } from "next-auth/next";

--- a/src/pages/network/index.tsx
+++ b/src/pages/network/index.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement } from "react";
+import type { ReactElement } from "react";
 import { LayoutAuthenticated } from "~/components/layouts/layout";
 import type { NextPageWithLayout } from "../_app";
 import { api } from "~/utils/api";
@@ -13,7 +13,7 @@ import {
 	useTrpcApiSuccessHandler,
 } from "~/hooks/useTrpcApiHandler";
 import Link from "next/link";
-import { User } from "@prisma/client";
+import type { User } from "@prisma/client";
 import { useRouter } from "next/router";
 
 type OrganizationId = {

--- a/src/server/api/__tests__/network/getUserNetworks.test.ts
+++ b/src/server/api/__tests__/network/getUserNetworks.test.ts
@@ -41,6 +41,7 @@ test("getUserNetworks", async () => {
 
 	interface NetworkMember {
 		id: string;
+		authorized: boolean;
 	}
 
 	const mockOutput: Network[] = [
@@ -56,9 +57,11 @@ test("getUserNetworks", async () => {
 			networkMembers: [
 				{
 					id: "4ef7287f63",
+					authorized: true,
 				},
 				{
 					id: "efcc1b0947",
+					authorized: true,
 				},
 			],
 		},

--- a/src/server/api/services/memberService.ts
+++ b/src/server/api/services/memberService.ts
@@ -60,6 +60,7 @@ export const syncMemberPeersAndStatus = async (
 			const updateData: Partial<network_members> = {
 				id: updatedMember.id,
 				address: updatedMember.address,
+				authorized: updatedMember.authorized,
 				online: memberIsOnline,
 			};
 


### PR DESCRIPTION
There was a performance issue caused by making individual API calls to zt controller for each member of each network when loading the network list. For instances with many networks and members, this resulted in hundreds of sequential API calls, significantly increasing network page load time.

This PR will add authorized status to database instead of making API calls.

**Note:** After updating, users will need to open each network individually to update the authorized status in the database. Until this is done, the "Nodes Act/Tot" column on the network page may display inaccurate information during initial load.


Resolves #638
