### PR TITLE
Fix: Handle orphaned network members gracefully

### DIFF
--- a/src/server/api/routers/organizationRouter.ts
+++ b/src/server/api/routers/organizationRouter.ts
@@ -382,21 +382,50 @@ export const organizationRouter = createTRPCRouter({
 			// Get authorized member and total member counts for each network
 			for (const network of organization.networks) {
 				for (const member of network.networkMembers) {
-					const memberDetails = await ztController.member_details(
-						ctx,
-						network.nwid,
-						member.id,
-					);
-					if (memberDetails.authorized) {
-						network.memberCounts.authorized += 1;
-						organization.memberCounts.authorized += 1;
+					try {
+						const memberDetails = await ztController.member_details(
+							ctx,
+							network.nwid,
+							member.id,
+						);
+						if (memberDetails.authorized) {
+							network.memberCounts.authorized += 1;
+							organization.memberCounts.authorized += 1;
+						}
+						network.memberCounts.total += 1;
+						organization.memberCounts.total += 1;
+					} catch (error) {
+						// Get status code directly from APIError
+						// biome-ignore lint/suspicious/noExplicitAny: <explanation>
+						const statusCode = (error as any).status;
+						if (statusCode === 404) {
+							// Safe to delete - member or network doesn't exist in ZeroTier
+							try {
+								await ctx.prisma.network_members.delete({
+									where: {
+										id_nwid: {
+											id: member.id,
+											nwid: member.nwid,
+										},
+									},
+								});
+								console.error(`Cleaned up orphaned member ${member.id} from database`);
+							} catch (cleanupError) {
+								console.error(
+									`Failed to cleanup orphaned member ${member.id}:`,
+									cleanupError,
+								);
+							}
+						} else {
+							// For any other error, just log and skip
+							console.error(
+								`Skipping member ${member.id} due to error: ${error.message}`,
+							);
+						}
 					}
-					network.memberCounts.total += 1;
-					organization.memberCounts.total += 1;
 				}
 				network.memberCounts.display = `${network.memberCounts.authorized} (${network.memberCounts.total})`;
 			}
-
 			organization.memberCounts.display = `${organization.memberCounts.authorized} (${organization.memberCounts.total})`;
 			return organization;
 		}),

--- a/src/utils/ztApi.ts
+++ b/src/utils/ztApi.ts
@@ -165,7 +165,7 @@ const getData = async <T>(
 				throw new APIError("Invalid API Key", error);
 			}
 			if (statusCode === 404) {
-				throw new APIError("Network Not Found", error);
+				throw new APIError("Network or Member Not Found", error);
 			}
 		}
 		const message = `An error occurred fetching data from ${addr}`;
@@ -610,17 +610,11 @@ export const member_details = async (
 ): Promise<MemberEntity> => {
 	// get headers based on local or central api
 	const { headers, ztCentralApiUrl, localControllerUrl } = await getOptions(ctx, central);
+	const addr = central
+		? `${ztCentralApiUrl}/network/${nwid}/member/${memberId}`
+		: `${localControllerUrl}/controller/network/${nwid}/member/${memberId}`;
 
-	try {
-		const addr = central
-			? `${ztCentralApiUrl}/network/${nwid}/member/${memberId}`
-			: `${localControllerUrl}/controller/network/${nwid}/member/${memberId}`;
-
-		return await getData<MemberEntity>(addr, headers);
-	} catch (error) {
-		const message = "Member not found!";
-		throw new APIError(message, error as AxiosError);
-	}
+	return await getData<MemberEntity>(addr, headers);
 };
 
 // Get all peers


### PR DESCRIPTION
When a member exists in the database but not in the ZeroTier controller, the network page would crash with "Member not found!" error. This PR automatically removes orphaned members from the database and allows the page to load successfully.