### PR TITLE
fix(api): lower required role to READ_ONLY on GET endpoints

### DIFF
--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -219,7 +219,7 @@ export const DELETE_orgStashNetworkMember = SecuredOrganizationApiRoute(
  * @returns The network member and associated network information.
  */
 export const GET_orgNetworkMemberById = SecuredOrganizationApiRoute(
-	{ requiredRole: Role.USER, requireNetworkId: true },
+	{ requiredRole: Role.READ_ONLY, requireNetworkId: true },
 	async (_req, res, context) => {
 		try {
 			const validatedContext = HandlerContextSchema.parse(context);

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/index.ts
@@ -40,7 +40,7 @@ export default async function apiNetworkMembersHandler(
 }
 
 export const GET_orgNetworkMembers = SecuredOrganizationApiRoute(
-	{ requiredRole: Role.USER, requireNetworkId: true },
+	{ requiredRole: Role.READ_ONLY, requireNetworkId: true },
 	async (_req, res, { networkId, orgId, ctx }) => {
 		try {
 			// Check if the user is an organization admin

--- a/src/pages/api/v1/org/[orgid]/network/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/index.ts
@@ -67,7 +67,7 @@ export const POST_orgCreateNewNetwork = SecuredOrganizationApiRoute(
 );
 
 export const GET_orgUserNetworks = SecuredOrganizationApiRoute(
-	{ requiredRole: Role.USER },
+	{ requiredRole: Role.READ_ONLY },
 	async (_req, res, { orgId, ctx }) => {
 		try {
 			// @ts-expect-error

--- a/src/pages/api/v1/org/[orgid]/user/index.ts
+++ b/src/pages/api/v1/org/[orgid]/user/index.ts
@@ -35,7 +35,7 @@ export default async function apiNetworkHandler(
 }
 
 const GET_organizationUsers = SecuredOrganizationApiRoute(
-	{ requiredRole: Role.USER },
+	{ requiredRole: Role.READ_ONLY },
 	async (_req, res, { orgId, ctx }) => {
 		try {
 			// @ts-expect-error ctx is not a valid parameter


### PR DESCRIPTION
Some member endpoints were incorrectly gated behind Role.USER even for read-only operations. This change drops the requirement to Role.READ_ONLY for all GET handlers while keeping write operations unchanged