### PR TITLE
Fix: Smart name resolution - preserve names from both database and controller sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 zeronsd.sh*
+
+# Claude
+CLAUDE.md
+settings.local.json


### PR DESCRIPTION
Enhances existing fix from #728 to support bidirectional name resolution.