### PR TITLE
Pin ZeroTier to version 1.14.2 in installation script

### DIFF
--- a/install.ztnet/bash/ztnet.sh
+++ b/install.ztnet/bash/ztnet.sh
@@ -101,6 +101,7 @@ print_ztnet
    ###    ##     ## ##     ## #### ##     ## ########  ######## ########  ######  
 
 INSTALLER_LAST_UPDATED=""
+ZEROTIER_VERSION="1.14.2"
 APT_PROGRAMS=("git" "curl" "jq" "postgresql" "postgresql-contrib")
 HOST_OS=$(( lsb_release -ds || cat /etc/*release || uname -om ) 2>/dev/null | head -n1)
 INSTALL_NODE=false
@@ -652,7 +653,7 @@ printf "\n\n${YELLOW}ZTNET installation script.${NC}\n"
 printf "This script will perform the following actions:\n"
 printf "  1. Install PostgreSQL if it's not already present.\n"
 printf "  2. Ensure Node.js version ${NODE_MAJOR} is installed.\n"
-printf "  3. Install Zerotier if it's missing.\n"
+printf "  3. Install Zerotier $ZEROTIER_VERSION if it's missing.\n"
 printf "  4. Clone the ZTnet repository into the /tmp folder and build artifacts from the latest tag.\n"
 printf "  5. Transfer the artifacts to the ${YELLOW}${TARGET_DIR}${NC} directory.\n\n"
 
@@ -922,9 +923,9 @@ export NODE_OPTIONS=--dns-result-order=ipv4first
 ######## ######## ##     ##  #######     ##    #### ######## ##     ## 
 
 setup_zerotier(){
-  # Install ZeroTier version 1.14.2
+  # Install ZeroTier version
   if ! command_exists zerotier-cli; then
-      print_status "Installing ZeroTier version 1.14.2..."
+      print_status "Installing ZeroTier version $ZEROTIER_VERSION..."
       
       # Detect distribution codename
       if command_exists lsb_release; then
@@ -939,19 +940,19 @@ setup_zerotier(){
       # Determine architecture for package name
       case "$ARCH" in
           "amd64")
-              ZT_PACKAGE="zerotier-one_1.14.2_amd64.deb"
+              ZT_PACKAGE="zerotier-one_${ZEROTIER_VERSION}_amd64.deb"
               ;;
           "arm64")
-              ZT_PACKAGE="zerotier-one_1.14.2_arm64.deb"
+              ZT_PACKAGE="zerotier-one_${ZEROTIER_VERSION}_arm64.deb"
               ;;
           *)
-              print_status ">>> Unsupported architecture for ZeroTier 1.14.2: $ARCH"
+              print_status ">>> Unsupported architecture for ZeroTier $ZEROTIER_VERSION: $ARCH"
               exit 1
               ;;
       esac
       
       # Download and install specific version from correct URL
-      $STD curl -o "$TEMP_INSTALL_DIR/$ZT_PACKAGE" "https://download.zerotier.com/RELEASES/1.14.2/dist/debian/$DISTRO_CODENAME/$ZT_PACKAGE"
+      $STD curl -o "$TEMP_INSTALL_DIR/$ZT_PACKAGE" "https://download.zerotier.com/RELEASES/$ZEROTIER_VERSION/dist/debian/$DISTRO_CODENAME/$ZT_PACKAGE"
       $STD sudo dpkg -i "$TEMP_INSTALL_DIR/$ZT_PACKAGE"
       $STD sudo apt-get install -f -y  # Fix any dependency issues
       

--- a/install.ztnet/src/index.ts
+++ b/install.ztnet/src/index.ts
@@ -4,6 +4,7 @@ import http from 'http';
 import express from 'express';
 import rateLimit from 'express-rate-limit';
 import { getBashInstaller } from './routes/getBashInstaller';
+import { getBetaInstaller } from './routes/getBetaInstaller';
 import path from 'path';
 import { postError } from './routes/postError';
 import { getHealth } from './routes/health';
@@ -41,6 +42,7 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
 app.get('/health', getHealthLimiter, getHealth);
+app.get('/beta', getRateLimiter, getBetaInstaller);
 app.get('(/)?', getRateLimiter, getBashInstaller);
 app.post('/post/error', errorRateLimiter, postError);
 app.get('*', (_, res) => res.download(path.join(__dirname, '..', 'bash/error.sh'), 'error.sh'));

--- a/install.ztnet/src/routes/getBetaInstaller.ts
+++ b/install.ztnet/src/routes/getBetaInstaller.ts
@@ -1,0 +1,37 @@
+import path from 'path';
+import { Request, Response } from 'express';
+import fs from 'fs';
+
+// Initialize a counter variable for beta downloads
+let betaDownloadCounter = 0;
+
+// Fetch beta bash script
+export const getBetaInstaller = async function (_req: Request, res: Response) {
+  const inst_path = `bash/ztnet_beta.sh`;
+  const filename = 'install_beta.sh';
+  const fileURL = path.join(__dirname, '..', '..', inst_path);
+  const options = {
+    headers: {
+      'x-timestamp': Date.now(),
+      'x-sent': true,
+      'content-disposition': 'attachment; filename=' + filename,
+    },
+  };
+
+  // Validate that file exists
+  fs.access(fileURL, fs.constants.R_OK, (err) => {
+    if (err) {
+      console.error(err);
+      res.download(path.join(__dirname, '..', '..', 'bash/error.sh'), 'error.sh', options);
+      return;
+    }
+
+    // File exists, increment the download counter and log it with the current date
+    betaDownloadCounter++;
+    const currentDate = new Date().toISOString();
+    console.log(`[${currentDate}] Beta bash file has been downloaded ${betaDownloadCounter} times.`);
+
+    // File exists
+    res.download(fileURL, 'install_beta.sh', options);
+  });
+};


### PR DESCRIPTION
As of ZeroTier version 1.16.0, the controller is no longer included in the official release due to licensing changes.
https://github.com/zerotier/ZeroTierOne/blob/dev/RELEASE-NOTES.md

This PR pins the ZeroTier version to 1.14.2, the last release where the controller was supported without requiring a commercial license.
