### PR TITLE
Fix member counting to exclude permanently deleted nodes

### DIFF
--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -86,11 +86,17 @@ export const networkRouter = createTRPCRouter({
 
 			// Process all networks and calculate member counts
 			const networks: NetworkWithMemberCount[] = rawNetworks.map((network) => {
-				// Count authorized members directly from database
+				// Only count truly active members (not deleted and not permanently deleted)
+				const activeMembersFilter = (m: network_members) =>
+					!m.deleted && !m.permanentlyDeleted;
+
+				// Count authorized active members
 				const authorizedCount = network.networkMembers.filter(
-					(m) => m.authorized && !m.deleted,
+					(m) => m.authorized && activeMembersFilter(m),
 				).length;
-				const totalCount = network.networkMembers.filter((m) => !m.deleted).length;
+
+				// Count total active members
+				const totalCount = network.networkMembers.filter(activeMembersFilter).length;
 
 				return {
 					...network,

--- a/src/server/api/routers/organizationRouter.ts
+++ b/src/server/api/routers/organizationRouter.ts
@@ -382,6 +382,11 @@ export const organizationRouter = createTRPCRouter({
 			// Get authorized member and total member counts for each network
 			for (const network of organization.networks) {
 				for (const member of network.networkMembers) {
+					// Skip deleted or permanently deleted members
+					if (member.deleted || member.permanentlyDeleted) {
+						continue;
+					}
+
 					try {
 						const memberDetails = await ztController.member_details(
 							ctx,


### PR DESCRIPTION
Fixes member counting logic in network and organization routers to properly exclude both deleted and permanently deleted members from active/total counts.

Resolves #748