### PR TITLE
[Fix] Do not send emails in background when testing emails

### DIFF
--- a/src/server/api/routers/adminRoute.ts
+++ b/src/server/api/routers/adminRoute.ts
@@ -611,6 +611,7 @@ export const adminRouter = createTRPCRouter({
 				to: user.email,
 				userId: user.id,
 				templateData,
+				sendInBackground: false, // Wait for actual SMTP response for test emails
 			});
 
 			return { success: true, message: `Test email for ${type} sent successfully` };

--- a/src/utils/mail.ts
+++ b/src/utils/mail.ts
@@ -170,8 +170,8 @@ export async function sendMailWithTemplate(
 		html: parsedTemplate.body,
 	};
 
-	// For test emails or when explicit synchronous sending is requested, wait for the result
-	// For production emails (default), send in background to avoid blocking
+	// If explicit synchronous sending is requested (sendInBackground === false), wait for the result
+	// Otherwise (default), send in background to avoid blocking
 	if (options.sendInBackground === false) {
 		await sendEmail(transporter, mailOptions);
 	} else {


### PR DESCRIPTION
This pull request introduces an improvement to the email sending workflow, specifically to allow test emails to be sent synchronously and to provide more control over email delivery timing. The main change is the addition of a `sendInBackground` option to the email sending logic, which ensures that test emails wait for the SMTP response instead of being sent in the background.

**Email sending workflow improvements:**

* Added an optional `sendInBackground` property to the `EmailOptions` interface in `mail.ts`, allowing callers to specify whether emails should be sent synchronously or asynchronously.
* Updated the `sendMailWithTemplate` function in `mail.ts` to check the `sendInBackground` flag and either await the SMTP result or send the email in the background accordingly. [[1]](diffhunk://#diff-32c62cd855339449b97c694c8c88fb89ca7b2f3efd06781bce3cf25cbfa8fef7R173-R177) [[2]](diffhunk://#diff-32c62cd855339449b97c694c8c88fb89ca7b2f3efd06781bce3cf25cbfa8fef7R187)

**Admin test email behavior:**

* Modified the admin test email route in `adminRoute.ts` to set `sendInBackground: false` for test emails, ensuring the function waits for the actual SMTP response before returning.


Resolves #752