### PR TITLE
Fix rate limiting issues and add configurable rate limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,8 +34,22 @@ MIGRATE_DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@localho
 
 # OAuth
 OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=true
-OAUTH_WELLKNOWN="https://accounts.google.com/.well-known/openid-configuration" 
+OAUTH_WELLKNOWN="https://accounts.google.com/.well-known/openid-configuration"
 OAUTH_ID=
 OAUTH_SECRET=
 OAUTH_EXCLUSIVE_LOGIN=false
 OAUTH_ALLOW_NEW_USERS=true
+
+# Rate Limiting - Authentication endpoints
+# Time window in minutes for auth rate limiting (default: 10)
+# RATE_LIMIT_WINDOW=10
+# Max requests for general operations like registration, token validation (default: 60)
+# RATE_LIMIT_MAX_REQUESTS=60
+# Max requests for sensitive operations like password reset, email verification (default: 10)
+# RATE_LIMIT_MAX_REQUESTS_SHORT=10
+
+# Rate Limiting - REST API endpoints (/api/v1/*)
+# Time window in minutes for REST API rate limiting (default: 1)
+# RATE_LIMIT_API_WINDOW=1
+# Max requests per window for REST API endpoints (default: 50)
+# RATE_LIMIT_API_MAX_REQUESTS=50

--- a/docs/docs/Installation/options.md
+++ b/docs/docs/Installation/options.md
@@ -136,4 +136,35 @@ For more information on NEXTAUTH environment variables, see [NEXTAUTH Environmen
   - Description: Duration (in seconds) before the user is logged out due to inactivity.
   - Default: 2592000 (30 Days).
 
+## Rate Limiting Configuration
+
+Rate limiting helps protect against brute force attacks and abuse. There are separate configurations for authentication endpoints and REST API endpoints.
+
+### Authentication Endpoints
+
+These settings control rate limiting for authentication operations (registration, password reset, email verification, MFA).
+
+- `RATE_LIMIT_WINDOW`
+  - Description: Time window in minutes for rate limit calculation. Requests are counted within this sliding window.
+  - Default: `10` (10 minutes).
+
+- `RATE_LIMIT_MAX_REQUESTS`
+  - Description: Maximum number of requests allowed within the rate limit window for general operations (e.g., registration, token validation).
+  - Default: `60`.
+
+- `RATE_LIMIT_MAX_REQUESTS_SHORT`
+  - Description: Maximum number of requests allowed within the rate limit window for sensitive operations (e.g., password reset requests, password changes, email verification).
+  - Default: `10`.
+
+### REST API Endpoints
+
+These settings control rate limiting for all REST API endpoints under `/api/v1/*`.
+
+- `RATE_LIMIT_API_WINDOW`
+  - Description: Time window in minutes for REST API rate limit calculation.
+  - Default: `1` (1 minute).
+
+- `RATE_LIMIT_API_MAX_REQUESTS`
+  - Description: Maximum number of requests allowed within the rate limit window for REST API endpoints.
+  - Default: `50`.
 

--- a/src/pages/api/__tests__/v1/network/networkById.test.ts
+++ b/src/pages/api/__tests__/v1/network/networkById.test.ts
@@ -30,6 +30,10 @@ jest.mock("~/utils/rateLimit", () => ({
 	default: jest.fn(() => ({
 		check: jest.fn().mockResolvedValue(null), // Mock implementation of the check method
 	})),
+	RATE_LIMIT_CONFIG: {
+		API_WINDOW_MS: 60 * 1000,
+		API_MAX_REQUESTS: 50,
+	},
 }));
 
 describe("/api/getNetworkById", () => {

--- a/src/pages/api/__tests__/v1/org/network/member/org.member.id.test.ts
+++ b/src/pages/api/__tests__/v1/org/network/member/org.member.id.test.ts
@@ -1,7 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import apiNetworkUpdateMembersHandler, {
-	REQUEST_PR_MINUTE,
-} from "~/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]";
+import apiNetworkUpdateMembersHandler from "~/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]";
+import { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import { createGenericApiTests } from "../../../apiAuthentication";
 
 jest.mock("~/server/db", () => ({
@@ -70,7 +69,7 @@ describe("organization network members api validation", () => {
 	);
 
 	test("should enforce rate limiting", async () => {
-		for (let i = 0; i < REQUEST_PR_MINUTE; i++) {
+		for (let i = 0; i < RATE_LIMIT_CONFIG.API_MAX_REQUESTS; i++) {
 			mockRequest.headers["x-ztnet-auth"] = `validToken${i}`;
 			await apiNetworkUpdateMembersHandler(
 				mockRequest as NextApiRequest,

--- a/src/pages/api/__tests__/v1/org/network/member/org.member.test.ts
+++ b/src/pages/api/__tests__/v1/org/network/member/org.member.test.ts
@@ -1,7 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import apiNetworkMembersHandler, {
-	REQUEST_PR_MINUTE,
-} from "~/pages/api/v1/org/[orgid]/network/[nwid]/member";
+import apiNetworkMembersHandler from "~/pages/api/v1/org/[orgid]/network/[nwid]/member";
+import { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import { createGenericApiTests } from "../../../apiAuthentication";
 
 jest.mock("~/server/db", () => ({
@@ -60,7 +59,7 @@ describe("organization network members api validation", () => {
 	);
 
 	test("should enforce rate limiting", async () => {
-		for (let i = 0; i < REQUEST_PR_MINUTE; i++) {
+		for (let i = 0; i < RATE_LIMIT_CONFIG.API_MAX_REQUESTS; i++) {
 			mockRequest.headers["x-ztnet-auth"] = `validToken${i}`;
 			await apiNetworkMembersHandler(
 				mockRequest as NextApiRequest,

--- a/src/pages/api/__tests__/v1/org/network/org.network.id.test.ts
+++ b/src/pages/api/__tests__/v1/org/network/org.network.id.test.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { REQUEST_PR_MINUTE } from "~/pages/api/v1/org/[orgid]/network/[nwid]";
 import apiNetworkHandler from "~/pages/api/v1/org/[orgid]/network/[nwid]";
+import { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import { createGenericApiTests } from "../../apiAuthentication";
 jest.mock("~/server/db", () => ({
 	prisma: {
@@ -56,7 +56,7 @@ describe("organization networkid api validation", () => {
 	describe("NetworkById PORT tests ", createGenericApiTests(apiNetworkHandler, "POST"));
 
 	test("should enforce rate limiting", async () => {
-		for (let i = 0; i < REQUEST_PR_MINUTE; i++) {
+		for (let i = 0; i < RATE_LIMIT_CONFIG.API_MAX_REQUESTS; i++) {
 			mockRequest.headers["x-ztnet-auth"] = `validToken${i}`;
 			await apiNetworkHandler(
 				mockRequest as NextApiRequest,

--- a/src/pages/api/__tests__/v1/org/network/org.network.test.ts
+++ b/src/pages/api/__tests__/v1/org/network/org.network.test.ts
@@ -1,5 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import apiNetworkHandler, { REQUEST_PR_MINUTE } from "~/pages/api/v1/org/[orgid]/network";
+import apiNetworkHandler from "~/pages/api/v1/org/[orgid]/network";
+import { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import { createGenericApiTests } from "../../apiAuthentication";
 
 jest.mock("~/server/db", () => ({
@@ -70,7 +71,7 @@ describe("organization network api validation", () => {
 	describe("NetworkById PORT tests ", createGenericApiTests(apiNetworkHandler, "POST"));
 
 	test("should enforce rate limiting", async () => {
-		for (let i = 0; i < REQUEST_PR_MINUTE; i++) {
+		for (let i = 0; i < RATE_LIMIT_CONFIG.API_MAX_REQUESTS; i++) {
 			mockRequest.headers["x-ztnet-auth"] = `validToken${i}`;
 			await apiNetworkHandler(
 				mockRequest as NextApiRequest,

--- a/src/pages/api/__tests__/v1/org/orgid.test.ts
+++ b/src/pages/api/__tests__/v1/org/orgid.test.ts
@@ -1,10 +1,8 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "~/server/db";
 import { API_TOKEN_SECRET, encrypt, generateInstanceSecret } from "~/utils/encryption";
-import apiNetworkHandler, {
-	GET_orgById,
-	REQUEST_PR_MINUTE,
-} from "~/pages/api/v1/org/[orgid]";
+import apiNetworkHandler, { GET_orgById } from "~/pages/api/v1/org/[orgid]";
+import { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 
 jest.mock("~/server/db", () => ({
 	prisma: {
@@ -170,7 +168,7 @@ describe("organization api validation", () => {
 	});
 
 	test("should enforce rate limiting", async () => {
-		for (let i = 0; i < REQUEST_PR_MINUTE; i++) {
+		for (let i = 0; i < RATE_LIMIT_CONFIG.API_MAX_REQUESTS; i++) {
 			mockRequest.headers["x-ztnet-auth"] = `validToken${i}`;
 			await apiNetworkHandler(
 				mockRequest as NextApiRequest,

--- a/src/pages/api/__tests__/v1/user/user.test.ts
+++ b/src/pages/api/__tests__/v1/user/user.test.ts
@@ -23,6 +23,10 @@ jest.mock("~/utils/rateLimit", () => ({
 	default: () => ({
 		check: jest.fn().mockResolvedValue(true),
 	}),
+	RATE_LIMIT_CONFIG: {
+		API_WINDOW_MS: 60 * 1000,
+		API_MAX_REQUESTS: 50,
+	},
 }));
 jest.mock("~/server/api/trpc");
 

--- a/src/pages/api/v1/network/[id]/index.ts
+++ b/src/pages/api/v1/network/[id]/index.ts
@@ -2,23 +2,25 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "~/server/db";
 import { SecuredPrivateApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import * as ztController from "~/utils/ztApi";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkByIdHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "NETWORKBYID_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"NETWORKBYID_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
@@ -4,7 +4,7 @@ import { appRouter } from "~/server/api/root";
 import { prisma } from "~/server/db";
 import { SecuredPrivateApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import * as ztController from "~/utils/ztApi";
 import {
 	deleteHandlerContextSchema,
@@ -12,20 +12,22 @@ import {
 	updateableFieldsMetaSchema,
 } from "./_schema";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkUpdateMembersHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "UPDATE_USER_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"UPDATE_USER_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/network/[id]/member/index.ts
+++ b/src/pages/api/v1/network/[id]/member/index.ts
@@ -2,23 +2,25 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "~/server/db";
 import { SecuredPrivateApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import * as ztController from "~/utils/ztApi";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkMembersHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "NETWORK_MEMBERS_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"NETWORK_MEMBERS_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/network/index.ts
+++ b/src/pages/api/v1/network/index.ts
@@ -3,24 +3,22 @@ import { networkProvisioningFactory } from "~/server/api/services/networkService
 import { prisma } from "~/server/db";
 import { SecuredPrivateApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import * as ztController from "~/utils/ztApi";
 import { createNetworkContextSchema } from "./_schema";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "NETWORK_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(res, RATE_LIMIT_CONFIG.API_MAX_REQUESTS, "NETWORK_CACHE_TOKEN");
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/org/[orgid]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/index.ts
@@ -3,22 +3,24 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { appRouter } from "~/server/api/root";
 import { SecuredOrganizationApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-export const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "ORGANIZATION_GET_CACHE_TOKEN");
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"ORGANIZATION_GET_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/index.ts
@@ -4,24 +4,26 @@ import { appRouter } from "~/server/api/root";
 import { prisma } from "~/server/db";
 import { SecuredOrganizationApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import * as ztController from "~/utils/ztApi";
 import { HandlerContextSchema, NetworkUpdateSchema } from "./_schema";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-export const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkByIdHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "ORGANIZATION_NETWORKID_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"ORGANIZATION_NETWORKID_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -4,25 +4,27 @@ import { appRouter } from "~/server/api/root";
 import { prisma } from "~/server/db";
 import { SecuredOrganizationApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 import { checkUserOrganizationRole } from "~/utils/role";
 import * as ztController from "~/utils/ztApi";
 import { HandlerContextSchema, PostBodySchema } from "./_schema";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-export const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkUpdateMembersHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "ORGANIZATION_MEMBERID_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"ORGANIZATION_MEMBERID_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/org/[orgid]/user/index.ts
+++ b/src/pages/api/v1/org/[orgid]/user/index.ts
@@ -3,22 +3,24 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { appRouter } from "~/server/api/root";
 import { SecuredOrganizationApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function apiNetworkHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "ORGANIZATION_GET_USER_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"ORGANIZATION_GET_USER_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/org/index.ts
+++ b/src/pages/api/v1/org/index.ts
@@ -3,22 +3,24 @@ import type { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "~/server/db";
 import { SecuredOrganizationApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function apiOrganizationHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "GET_ORGANIZATION_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(
+			res,
+			RATE_LIMIT_CONFIG.API_MAX_REQUESTS,
+			"GET_ORGANIZATION_CACHE_TOKEN",
+		);
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/pages/api/v1/stats/index.ts
+++ b/src/pages/api/v1/stats/index.ts
@@ -3,22 +3,20 @@ import { prisma } from "~/server/db";
 import { SecuredPrivateApiRoute } from "~/utils/apiRouteAuth";
 import { handleApiErrors } from "~/utils/errors";
 import { globalSiteVersion } from "~/utils/global";
-import rateLimit from "~/utils/rateLimit";
+import rateLimit, { RATE_LIMIT_CONFIG } from "~/utils/rateLimit";
 
-// Number of allowed requests per minute
+// Rate limit using environment configuration
 const limiter = rateLimit({
-	interval: 60 * 1000, // 60 seconds
-	uniqueTokenPerInterval: 500, // Max 500 users per second
+	interval: RATE_LIMIT_CONFIG.API_WINDOW_MS,
+	uniqueTokenPerInterval: 500,
 });
-
-const REQUEST_PR_MINUTE = 50;
 
 export default async function createStatsHandler(
 	req: NextApiRequest,
 	res: NextApiResponse,
 ) {
 	try {
-		await limiter.check(res, REQUEST_PR_MINUTE, "CREATE_USER_CACHE_TOKEN"); // 10 requests per minute
+		await limiter.check(res, RATE_LIMIT_CONFIG.API_MAX_REQUESTS, "STATS_CACHE_TOKEN");
 	} catch {
 		return res.status(429).json({ error: "Rate limit exceeded" });
 	}

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -35,6 +35,17 @@ const limiter = rateLimit({
 const GENERAL_REQUEST_LIMIT = 60;
 const SHORT_REQUEST_LIMIT = 5;
 
+// Rate limit tokens - each endpoint should have its own token to prevent
+// different operations from consuming each other's rate limits
+const RATE_LIMIT_TOKENS = {
+	REGISTER_USER: "REGISTER_USER",
+	VALIDATE_RESET_TOKEN: "VALIDATE_RESET_TOKEN",
+	PASSWORD_RESET_LINK: "PASSWORD_RESET_LINK",
+	CHANGE_PASSWORD: "CHANGE_PASSWORD",
+	SEND_EMAIL_VERIFICATION: "SEND_EMAIL_VERIFICATION",
+	EMAIL_VERIFICATION_LINK: "EMAIL_VERIFICATION_LINK",
+} as const;
+
 export const authRouter = createTRPCRouter({
 	register: publicProcedure
 		.input(
@@ -54,7 +65,11 @@ export const authRouter = createTRPCRouter({
 		.mutation(async ({ ctx, input }) => {
 			// add rate limit
 			try {
-				await limiter.check(ctx.res, GENERAL_REQUEST_LIMIT, "REGISTER_USER");
+				await limiter.check(
+					ctx.res,
+					GENERAL_REQUEST_LIMIT,
+					RATE_LIMIT_TOKENS.REGISTER_USER,
+				);
 			} catch {
 				throw new TRPCError({
 					code: "TOO_MANY_REQUESTS",
@@ -456,7 +471,11 @@ export const authRouter = createTRPCRouter({
 
 				// add rate limit
 				try {
-					await limiter.check(ctx.res, GENERAL_REQUEST_LIMIT, "PASSWORD_RESET_LINK");
+					await limiter.check(
+						ctx.res,
+						GENERAL_REQUEST_LIMIT,
+						RATE_LIMIT_TOKENS.VALIDATE_RESET_TOKEN,
+					);
 				} catch {
 					throw new TRPCError({
 						code: "TOO_MANY_REQUESTS",
@@ -490,7 +509,11 @@ export const authRouter = createTRPCRouter({
 		.mutation(async ({ ctx, input }) => {
 			const { email } = input;
 			try {
-				await limiter.check(ctx.res, SHORT_REQUEST_LIMIT, "PASSWORD_RESET_LINK");
+				await limiter.check(
+					ctx.res,
+					SHORT_REQUEST_LIMIT,
+					RATE_LIMIT_TOKENS.PASSWORD_RESET_LINK,
+				);
 			} catch {
 				throw new TRPCError({
 					code: "TOO_MANY_REQUESTS",
@@ -553,7 +576,11 @@ export const authRouter = createTRPCRouter({
 		.mutation(async ({ ctx, input }) => {
 			const { token, password, newPassword } = input;
 			try {
-				await limiter.check(ctx.res, SHORT_REQUEST_LIMIT, "PASSWORD_RESET_LINK");
+				await limiter.check(
+					ctx.res,
+					SHORT_REQUEST_LIMIT,
+					RATE_LIMIT_TOKENS.CHANGE_PASSWORD,
+				);
 			} catch {
 				throw new TRPCError({
 					code: "TOO_MANY_REQUESTS",
@@ -601,7 +628,11 @@ export const authRouter = createTRPCRouter({
 	sendVerificationEmail: protectedProcedure.mutation(async ({ ctx }) => {
 		// add cooldown to prevent spam
 		try {
-			await limiter.check(ctx.res, SHORT_REQUEST_LIMIT, "SEND_EMAIL_VERIFICATION");
+			await limiter.check(
+				ctx.res,
+				SHORT_REQUEST_LIMIT,
+				RATE_LIMIT_TOKENS.SEND_EMAIL_VERIFICATION,
+			);
 		} catch {
 			throw new TRPCError({
 				code: "TOO_MANY_REQUESTS",
@@ -659,7 +690,11 @@ export const authRouter = createTRPCRouter({
 		.query(async ({ ctx, input }) => {
 			// add rate limit
 			try {
-				await limiter.check(ctx.res, SHORT_REQUEST_LIMIT, "EMAIL_VERIFICATION_LINK");
+				await limiter.check(
+					ctx.res,
+					SHORT_REQUEST_LIMIT,
+					RATE_LIMIT_TOKENS.EMAIL_VERIFICATION_LINK,
+				);
 			} catch {
 				throw new TRPCError({
 					code: "TOO_MANY_REQUESTS",

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -26,14 +26,21 @@ import { ErrorCode } from "~/utils/errorCode";
 import { MailTemplateKey } from "~/utils/enums";
 import { mediumPassword, passwordSchema } from "./_schema";
 
-// allow 15 requests per 10 minutes
+// Rate limit configuration from environment variables
+// RATE_LIMIT_WINDOW: Time window in minutes (default: 10 minutes)
+// RATE_LIMIT_MAX_REQUESTS: Max requests for general operations (default: 60)
+// RATE_LIMIT_MAX_REQUESTS_SHORT: Max requests for sensitive operations (default: 5)
+const RATE_LIMIT_WINDOW_MS =
+	(Number.parseInt(process.env.RATE_LIMIT_WINDOW || "10", 10) || 10) * 60 * 1000;
+const GENERAL_REQUEST_LIMIT =
+	Number.parseInt(process.env.RATE_LIMIT_MAX_REQUESTS || "60", 10) || 60;
+const SHORT_REQUEST_LIMIT =
+	Number.parseInt(process.env.RATE_LIMIT_MAX_REQUESTS_SHORT || "10", 10) || 10;
+
 const limiter = rateLimit({
-	interval: 10 * 60 * 1000, // 600 seconds or 10 minutes
+	interval: RATE_LIMIT_WINDOW_MS,
 	uniqueTokenPerInterval: 1000,
 });
-
-const GENERAL_REQUEST_LIMIT = 60;
-const SHORT_REQUEST_LIMIT = 5;
 
 // Rate limit tokens - each endpoint should have its own token to prevent
 // different operations from consuming each other's rate limits

--- a/src/server/api/routers/organizationRouter.ts
+++ b/src/server/api/routers/organizationRouter.ts
@@ -40,8 +40,12 @@ import { MemberCounts } from "~/types/local/member";
 // Create a Zod schema for the HookType enum
 const HookTypeEnum = z.enum(Object.values(HookType) as [HookType, ...HookType[]]);
 
+// Rate limit configuration from environment variables
+const RATE_LIMIT_WINDOW_MS =
+	(Number.parseInt(process.env.RATE_LIMIT_WINDOW || "10", 10) || 10) * 60 * 1000;
+
 const invitationRateLimit = rateLimit({
-	interval: 5 * 60 * 1000, // 300 seconds or 5 minutes
+	interval: RATE_LIMIT_WINDOW_MS,
 	uniqueTokenPerInterval: 1000,
 });
 

--- a/src/utils/rateLimit.ts
+++ b/src/utils/rateLimit.ts
@@ -6,6 +6,17 @@ type Options = {
 	interval?: number;
 };
 
+// Rate limit configuration from environment variables
+// These are exported so they can be used by API routes
+export const RATE_LIMIT_CONFIG = {
+	// Time window in minutes (default: 1 minute for REST API)
+	API_WINDOW_MS:
+		(Number.parseInt(process.env.RATE_LIMIT_API_WINDOW || "1", 10) || 1) * 60 * 1000,
+	// Max requests per window for REST API (default: 50)
+	API_MAX_REQUESTS:
+		Number.parseInt(process.env.RATE_LIMIT_API_MAX_REQUESTS || "50", 10) || 50,
+} as const;
+
 export default function rateLimit(options?: Options) {
 	const tokenCache = new LRUCache({
 		max: options?.uniqueTokenPerInterval || 500,


### PR DESCRIPTION
- Fix rate limiting bug where password reset operations shared the same token, causing users to hit rate limits during normal
  password reset flows
- Add configurable rate limits via environment variables
- Each auth endpoint now has its own dedicated rate limit token

New Environment Variables

| Variable                      | Description                                 | Default |
|-------------------------------|---------------------------------------------|---------|
| RATE_LIMIT_WINDOW             | Auth rate limit window (minutes)            | 10      |
| RATE_LIMIT_MAX_REQUESTS       | General auth operations                     | 60      |
| RATE_LIMIT_MAX_REQUESTS_SHORT | Sensitive operations (password reset, etc.) | 10      |
| RATE_LIMIT_API_WINDOW         | REST API window (minutes)                   | 1       |
| RATE_LIMIT_API_MAX_REQUESTS   | REST API requests                           | 50      |

resolves #802