### PR TITLE
Fix org API unable to create new network members

### DIFF
--- a/docs/docs/Rest Api/Organization/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Organization/_source/networkMember.yml
@@ -96,7 +96,8 @@ paths:
 
     post:
       summary: Modify a organization network member
-      description: Modify a organization network member
+      description: |
+        Modify a organization network member. This endpoint can also be used to pre-authorize a member that has not yet joined the network by providing their ZeroTier node ID as the `memberId`. If the member does not yet exist in the database, it will be created on the ZeroTier controller and returned in the response.
       parameters:
         - in: path
           name: networkId

--- a/docs/docs/Rest Api/Personal/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Personal/_source/networkMember.yml
@@ -52,7 +52,8 @@ paths:
   /network/{networkId}/member/{memberId}:
     post:
       summary: Modify a network member
-      description: Modify a network member
+      description: |
+        Modify a network member. This endpoint can also be used to pre-authorize a member that has not yet joined the network by providing their ZeroTier node ID as the `memberId`. If the member does not yet exist in the database, it will be created on the ZeroTier controller and returned in the response.
       parameters:
         - in: path
           name: networkId

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -163,7 +163,7 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 						address: memberId,
 						lastSeen: new Date(),
 						creationTime: new Date(),
-						name: databasePayload.name as string || null,
+						name: (databasePayload.name as string) || null,
 						nwid_ref: { connect: { nwid: networkId } },
 					},
 				});


### PR DESCRIPTION
The organization-level member API endpoint (/api/v1/org/{orgId}/network/{nwid}/member/{memberId}) failed with
"Member or Network not found" when the member didn't already exist in the database.

The endpoint now creates a database record for new members and forwards the request to the ZeroTier controller,
matching the behavior of the personal network API endpoint. Also updated API docs to document that the modify
endpoint can be used to pre-authorize members.

Fixes #833