### PR TITLE
Fix network and organization authorization checks

### DIFF
--- a/src/server/api/__tests__/network/networkAccessControl.test.ts
+++ b/src/server/api/__tests__/network/networkAccessControl.test.ts
@@ -1,0 +1,393 @@
+import { PrismaClient } from "@prisma/client";
+import { type Session } from "next-auth";
+import { appRouter } from "../../root";
+import { type PartialDeep } from "type-fest";
+
+// Mock ztController to prevent actual ZeroTier API calls
+jest.mock("~/utils/ztApi", () => ({
+	network_update: jest.fn().mockResolvedValue({}),
+	network_delete: jest.fn().mockResolvedValue({}),
+	network_members: jest.fn().mockResolvedValue({}),
+	member_update: jest.fn().mockResolvedValue({}),
+	get_network: jest.fn().mockResolvedValue({ v6AssignMode: {} }),
+	member_details: jest.fn().mockResolvedValue({}),
+	local_network_and_members: jest.fn().mockResolvedValue({ members: [] }),
+}));
+
+jest.mock("~/utils/webhook", () => ({
+	sendWebhook: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("~/utils/mail", () => ({
+	sendMailWithTemplate: jest.fn().mockResolvedValue(undefined),
+}));
+
+const prisma = new PrismaClient();
+
+const ownerSession: PartialDeep<Session> = {
+	expires: new Date().toISOString(),
+	update: { name: "test" },
+	user: {
+		id: "owner-user-id",
+		name: "Network Owner",
+		email: "owner@test.com",
+	},
+};
+
+const attackerSession: PartialDeep<Session> = {
+	expires: new Date().toISOString(),
+	update: { name: "test" },
+	user: {
+		id: "attacker-user-id",
+		name: "Attacker",
+		email: "attacker@test.com",
+	},
+};
+
+const orgMemberSession: PartialDeep<Session> = {
+	expires: new Date().toISOString(),
+	update: { name: "test" },
+	user: {
+		id: "org-member-id",
+		name: "Org Member",
+		email: "orgmember@test.com",
+	},
+};
+
+const createCaller = (session: PartialDeep<Session>) =>
+	appRouter.createCaller({
+		session: session as Session,
+		wss: null,
+		prisma: prisma,
+		res: null,
+	});
+
+// Helper to mock a personal network (no organizationId)
+const mockPersonalNetwork = (authorId: string) => {
+	prisma.network.findUnique = jest.fn().mockResolvedValue({
+		authorId,
+		organizationId: null,
+	});
+};
+
+// Helper to mock an organization network
+const mockOrgNetwork = (authorId: string, organizationId: string) => {
+	prisma.network.findUnique = jest.fn().mockResolvedValue({
+		authorId,
+		organizationId,
+	});
+};
+
+/**
+ * Helper to mock organization role check.
+ * checkNetworkAccess now delegates to checkUserOrganizationRole for org networks,
+ * which queries userOrganizationRole.findFirst to verify the user's role.
+ */
+const mockOrgRole = (role: string | null) => {
+	prisma.userOrganizationRole.findFirst = jest
+		.fn()
+		.mockResolvedValue(role ? { role } : null);
+};
+
+// Helper to mock non-existent network
+const mockNetworkNotFound = () => {
+	prisma.network.findUnique = jest.fn().mockResolvedValue(null);
+};
+
+describe("checkNetworkAccess - helper behavior via endpoints", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe("Network not found", () => {
+		it("should reject when network does not exist", async () => {
+			mockNetworkNotFound();
+			const caller = createCaller(ownerSession);
+
+			await expect(
+				caller.network.getFlowRule({ nwid: "nonexistent", central: false }),
+			).rejects.toThrow(
+				expect.objectContaining({
+					code: "NOT_FOUND",
+				}),
+			);
+		});
+	});
+
+	describe("Personal network - owner access", () => {
+		it("should allow network owner to access getFlowRule", async () => {
+			mockPersonalNetwork("owner-user-id");
+			prisma.network.findFirst = jest.fn().mockResolvedValue({ flowRule: "accept;" });
+
+			const caller = createCaller(ownerSession);
+			const result = await caller.network.getFlowRule({
+				nwid: "test-nwid",
+				central: false,
+			});
+			expect(result).toBe("accept;");
+		});
+
+		it("should allow network owner to access getAnotation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			prisma.notation.findMany = jest.fn().mockResolvedValue([]);
+
+			const caller = createCaller(ownerSession);
+			const result = await caller.network.getAnotation({
+				nwid: "test-nwid",
+			});
+			expect(result).toEqual([]);
+		});
+	});
+
+	describe("Personal network - non-owner rejection", () => {
+		it("should reject non-owner from getFlowRule", async () => {
+			mockPersonalNetwork("owner-user-id");
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.getFlowRule({
+					nwid: "test-nwid",
+					central: false,
+				}),
+			).rejects.toThrow("You do not have access to this network!");
+		});
+
+		it("should reject non-owner from getAnotation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			const caller = createCaller(attackerSession);
+
+			await expect(caller.network.getAnotation({ nwid: "test-nwid" })).rejects.toThrow(
+				"You do not have access to this network!",
+			);
+		});
+
+		it("should reject non-owner from networkName mutation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.networkName({
+					nwid: "test-nwid",
+					central: false,
+					updateParams: { name: "hacked" },
+				}),
+			).rejects.toThrow("You do not have access to this network!");
+		});
+
+		it("should reject non-owner from deleteNetwork mutation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.deleteNetwork({
+					nwid: "test-nwid",
+					central: false,
+				}),
+			).rejects.toThrow("You do not have access to this network!");
+		});
+
+		it("should reject non-owner from networkDescription mutation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.networkDescription({
+					nwid: "test-nwid",
+					central: false,
+					updateParams: { description: "hacked" },
+				}),
+			).rejects.toThrow("You do not have access to this network!");
+		});
+
+		it("should reject non-owner from setFlowRule mutation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.setFlowRule({
+					nwid: "test-nwid",
+					central: false,
+					updateParams: { flowRoute: "drop;" },
+				}),
+			).rejects.toThrow("You do not have access to this network!");
+		});
+	});
+
+	describe("Organization network - role-based access", () => {
+		it("should allow org USER to access org network via getFlowRule (read)", async () => {
+			mockOrgNetwork("owner-user-id", "org-1");
+			mockOrgRole("USER");
+			prisma.network.findFirst = jest.fn().mockResolvedValue({ flowRule: "accept;" });
+
+			const caller = createCaller(orgMemberSession);
+			const result = await caller.network.getFlowRule({
+				nwid: "test-nwid",
+				central: false,
+			});
+			expect(result).toBe("accept;");
+		});
+
+		it("should allow org READ_ONLY to access org network via getFlowRule (read)", async () => {
+			mockOrgNetwork("owner-user-id", "org-1");
+			mockOrgRole("READ_ONLY");
+			prisma.network.findFirst = jest.fn().mockResolvedValue({ flowRule: "accept;" });
+
+			const caller = createCaller(orgMemberSession);
+			const result = await caller.network.getFlowRule({
+				nwid: "test-nwid",
+				central: false,
+			});
+			expect(result).toBe("accept;");
+		});
+
+		it("should reject non-member from org network", async () => {
+			mockOrgNetwork("owner-user-id", "org-1");
+			mockOrgRole(null); // not a member
+
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.getFlowRule({
+					nwid: "test-nwid",
+					central: false,
+				}),
+			).rejects.toThrow();
+		});
+
+		it("should reject org READ_ONLY user from networkName mutation", async () => {
+			mockOrgNetwork("owner-user-id", "org-1");
+			mockOrgRole("READ_ONLY");
+
+			const caller = createCaller(orgMemberSession);
+
+			await expect(
+				caller.network.networkName({
+					nwid: "test-nwid",
+					central: false,
+					updateParams: { name: "new-name" },
+				}),
+			).rejects.toThrow();
+		});
+
+		it("should allow org USER to perform networkName mutation", async () => {
+			mockOrgNetwork("owner-user-id", "org-1");
+			mockOrgRole("USER");
+			prisma.activityLog.create = jest.fn().mockResolvedValue({});
+			prisma.network.update = jest.fn().mockResolvedValue({});
+
+			const caller = createCaller(orgMemberSession);
+			// Should not throw - USER role meets Role.USER minimum
+			await expect(
+				caller.network.networkName({
+					nwid: "test-nwid",
+					central: false,
+					updateParams: { name: "new-name" },
+				}),
+			).resolves.toBeDefined();
+		});
+	});
+
+	describe("Activity log not created for unauthorized requests", () => {
+		it("should not create activity log when non-owner attempts networkName mutation", async () => {
+			mockPersonalNetwork("owner-user-id");
+			prisma.activityLog.create = jest.fn().mockResolvedValue({});
+			const caller = createCaller(attackerSession);
+
+			await expect(
+				caller.network.networkName({
+					nwid: "test-nwid",
+					central: false,
+					updateParams: { name: "hacked" },
+				}),
+			).rejects.toThrow("You do not have access to this network!");
+
+			// The activity log should NOT have been created since auth check runs first
+			expect(prisma.activityLog.create).not.toHaveBeenCalled();
+		});
+	});
+});
+
+describe("Member router access control", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("should reject non-owner from getMemberById", async () => {
+		mockPersonalNetwork("owner-user-id");
+		const caller = createCaller(attackerSession);
+
+		await expect(
+			caller.networkMember.getMemberById({
+				nwid: "test-nwid",
+				id: "member-id",
+				central: false,
+			}),
+		).rejects.toThrow("You do not have access to this network!");
+	});
+
+	it("should reject non-owner from getMemberAnotations", async () => {
+		mockPersonalNetwork("owner-user-id");
+		const caller = createCaller(attackerSession);
+
+		await expect(
+			caller.networkMember.getMemberAnotations({
+				nwid: "test-nwid",
+				nodeid: 1,
+			}),
+		).rejects.toThrow("You do not have access to this network!");
+	});
+
+	it("should allow owner to access getMemberById", async () => {
+		mockPersonalNetwork("owner-user-id");
+		prisma.network_members.findFirst = jest.fn().mockResolvedValue({
+			id: "member-id",
+			nwid: "test-nwid",
+		});
+
+		const caller = createCaller(ownerSession);
+		const result = await caller.networkMember.getMemberById({
+			nwid: "test-nwid",
+			id: "member-id",
+			central: false,
+		});
+		expect(result).toBeDefined();
+	});
+});
+
+describe("Organization router access control", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("should reject non-member from markMessagesAsRead", async () => {
+		// Mock the org role check to fail (user not in org)
+		prisma.userOrganizationRole.findFirst = jest.fn().mockResolvedValue(null);
+
+		const caller = createCaller(attackerSession);
+
+		await expect(
+			caller.org.markMessagesAsRead({
+				organizationId: "org-1",
+			}),
+		).rejects.toThrow();
+	});
+
+	it("should allow org member to markMessagesAsRead", async () => {
+		// Mock the org role check to succeed
+		prisma.userOrganizationRole.findFirst = jest.fn().mockResolvedValue({ role: "USER" });
+		prisma.messages.findFirst = jest
+			.fn()
+			.mockResolvedValue({ id: 1, organizationId: "org-1" });
+		prisma.lastReadMessage.upsert = jest.fn().mockResolvedValue({
+			userId: "org-member-id",
+			organizationId: "org-1",
+			lastMessageId: 1,
+		});
+
+		const caller = createCaller(orgMemberSession);
+		const result = await caller.org.markMessagesAsRead({
+			organizationId: "org-1",
+		});
+		expect(result).toBeDefined();
+	});
+});

--- a/src/server/api/__tests__/networkMembers/updateDatabaseOnly.test.ts
+++ b/src/server/api/__tests__/networkMembers/updateDatabaseOnly.test.ts
@@ -52,6 +52,15 @@ test("updateDatabaseOnly test", async () => {
 		res: null,
 	});
 
+	// Mock network access check - return network owned by the test user
+	prisma.network.findUnique.mockResolvedValue({
+		authorId: "userid",
+		organizationId: null,
+	} as never);
+
+	// Mock activity log creation
+	prisma.activityLog.create.mockResolvedValue({} as never);
+
 	// @ts-expect-error -- awaiting fix:
 	prisma.network.update.mockResolvedValue(mockOutput);
 

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -982,6 +982,18 @@ export const authRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Verify the device belongs to the current user before deleting
+			const device = await ctx.prisma.userDevice.findUnique({
+				where: {
+					deviceId: input.deviceId,
+				},
+				select: { userId: true },
+			});
+
+			if (!device || device.userId !== ctx.session.user.id) {
+				throw new Error("Device not found or you do not have permission to delete it.");
+			}
+
 			await ctx.prisma.userDevice.delete({
 				where: {
 					deviceId: input.deviceId,

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -8,7 +8,7 @@ import { sendMailWithTemplate } from "~/utils/mail";
 import type { TagsByName, NetworkEntity, RoutesEntity } from "~/types/local/network";
 import type { MemberEntity, CapabilitiesByName } from "~/types/local/member";
 import type { CentralNetwork } from "~/types/central/network";
-import { checkUserOrganizationRole } from "~/utils/role";
+import { checkNetworkAccess } from "~/utils/networkAccess";
 import { type network, type network_members, Role } from "@prisma/client";
 import {
 	HookType,
@@ -355,14 +355,8 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
-			// Check if the user has permission to update the network
-			if (input.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
 
 			try {
 				// De-authorize all members before deleting the network
@@ -483,6 +477,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -494,14 +491,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			const network = await ztController.get_network(ctx, input.nwid, input.central);
 			// prepare update params
 			const updateParams = input.central
@@ -552,6 +541,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -561,14 +553,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			// if central is true, send the request to the central API and return the response
 			const { v4AssignMode } = input.updateParams;
 			// prepare update params
@@ -614,6 +598,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -624,15 +611,6 @@ export const networkRouter = createTRPCRouter({
 					organizationId: input?.organizationId || null, // Use null if organizationId is not provided
 				},
 			});
-
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 
 			const { note, via } = input.updateParams;
 
@@ -709,6 +687,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			await ctx.prisma.activityLog.create({
 				data: {
 					action: `Changed network ${input.nwid} IP assignment to ${JSON.stringify(
@@ -719,14 +700,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			// generate network params
 			const { ipAssignmentPools, routes, v4AssignMode } = IPv4gen(
 				input.updateParams.routes[0].target,
@@ -777,6 +750,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -787,15 +763,6 @@ export const networkRouter = createTRPCRouter({
 					organizationId: input?.organizationId || null, // Use null if organizationId is not provided
 				},
 			});
-
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 
 			// Validate the IP ranges
 			for (const ipRange of input.updateParams.ipAssignmentPools) {
@@ -892,6 +859,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -900,15 +870,6 @@ export const networkRouter = createTRPCRouter({
 					organizationId: input?.organizationId || null, // Use null if organizationId is not provided
 				},
 			});
-
-			// Check if the user has permission to update the network
-			if (input.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 
 			const updateParams = input.central
 				? { config: { private: input.updateParams.private } }
@@ -956,6 +917,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -965,14 +929,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			const updateParams = input.central
 				? { config: { ...input.updateParams } }
 				: { ...input.updateParams };
@@ -1026,6 +982,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1035,14 +994,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			// if central is true, send the request to the central API and return the response
 			if (input.central) {
 				const updated = await ztController.network_update({
@@ -1112,6 +1063,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1122,15 +1076,6 @@ export const networkRouter = createTRPCRouter({
 					organizationId: input?.organizationId || null, // Use null if organizationId is not provided
 				},
 			});
-
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 
 			let ztControllerUpdates = {};
 
@@ -1181,6 +1126,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1192,14 +1140,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			const updateParams = input.central
 				? { config: { ...input.updateParams } }
 				: { ...input.updateParams };
@@ -1248,6 +1188,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1259,14 +1202,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			const updateParams = input.central
 				? { config: { ...input.updateParams } }
 				: { ...input.updateParams };
@@ -1323,6 +1258,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1332,14 +1270,6 @@ export const networkRouter = createTRPCRouter({
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			const { flowRoute } = input.updateParams;
 
 			const rules = [];
@@ -1446,6 +1376,9 @@ export const networkRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.READ_ONLY);
+
 			const DEFAULT_NETWORK_ROUTE_CONFIG = `#
 # This is a default rule set that allows IPv4 and IPv6 traffic but otherwise
 # behaves like a standard Ethernet switch.
@@ -1512,6 +1445,9 @@ accept;`;
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1521,14 +1457,6 @@ accept;`;
 				},
 			});
 
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 			const { nwid, email } = input;
 			try {
 				await sendMailWithTemplate(MailTemplateKey.InviteUser, {
@@ -1558,6 +1486,9 @@ accept;`;
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.USER);
+
 			// Log the action
 			await ctx.prisma.activityLog.create({
 				data: {
@@ -1566,15 +1497,6 @@ accept;`;
 					organizationId: input?.organizationId || null, // Use null if organizationId is not provided
 				},
 			});
-
-			// Check if the user has permission to update the network
-			if (input?.organizationId) {
-				await checkUserOrganizationRole({
-					ctx,
-					organizationId: input?.organizationId,
-					minimumRequiredRole: Role.USER,
-				});
-			}
 
 			const notation = await ctx.prisma.notation.upsert({
 				where: {
@@ -1614,6 +1536,9 @@ accept;`;
 			}),
 		)
 		.query(async ({ ctx, input }) => {
+			// Check if the user has permission to access this network
+			await checkNetworkAccess(ctx, input.nwid, Role.READ_ONLY);
+
 			return await ctx.prisma.notation.findMany({
 				where: {
 					nwid: input.nwid,

--- a/src/server/api/routers/organizationRouter.ts
+++ b/src/server/api/routers/organizationRouter.ts
@@ -1667,27 +1667,6 @@ export const organizationRouter = createTRPCRouter({
 				},
 			});
 		}),
-	getOrgWebhooks: protectedProcedure
-		.input(
-			z.object({
-				organizationId: z.string(),
-			}),
-		)
-		.query(async ({ ctx, input }) => {
-			// make sure the user is member of the organization
-			await checkUserOrganizationRole({
-				ctx,
-				organizationId: input.organizationId,
-				minimumRequiredRole: Role.ADMIN,
-			});
-
-			// get all webhooks related to the organization
-			return await ctx.prisma.webhook.findMany({
-				where: {
-					organizationId: input.organizationId,
-				},
-			});
-		}),
 	updateOrganizationSettings: protectedProcedure
 		.input(
 			z.object({

--- a/src/server/api/routers/organizationRouter.ts
+++ b/src/server/api/routers/organizationRouter.ts
@@ -782,6 +782,13 @@ export const organizationRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user is a member of this organization
+			await checkUserOrganizationRole({
+				ctx,
+				organizationId: input.organizationId,
+				minimumRequiredRole: Role.READ_ONLY,
+			});
+
 			// Get the current user's ID
 			const userId = ctx.session.user.id;
 			// Find the latest message in the organization
@@ -1236,6 +1243,13 @@ export const organizationRouter = createTRPCRouter({
 			}),
 		)
 		.mutation(async ({ ctx, input }) => {
+			// Check if the user has permission to generate invite links for this org
+			await checkUserOrganizationRole({
+				ctx,
+				organizationId: input.organizationId,
+				minimumRequiredRole: Role.ADMIN,
+			});
+
 			const payload = {
 				email: input.email,
 				organizationId: input.organizationId,
@@ -1667,10 +1681,10 @@ export const organizationRouter = createTRPCRouter({
 				minimumRequiredRole: Role.ADMIN,
 			});
 
-			// get all organizations related to the user
+			// get all webhooks related to the organization
 			return await ctx.prisma.webhook.findMany({
 				where: {
-					id: input.organizationId,
+					organizationId: input.organizationId,
 				},
 			});
 		}),

--- a/src/utils/networkAccess.ts
+++ b/src/utils/networkAccess.ts
@@ -1,0 +1,58 @@
+import { throwError } from "~/server/helpers/errorHandler";
+import { checkUserOrganizationRole } from "~/utils/role";
+import { type Role } from "@prisma/client";
+
+/**
+ * Checks if the current user has access to a network by verifying:
+ *
+ * For personal networks (no organizationId on the network in DB):
+ *   - The user must be the author (owner) of the network
+ *
+ * For organization networks (organizationId exists on the network in DB):
+ *   - The user must be a member of that organization with at least `minimumRequiredRole`
+ *
+ * The organizationId is always looked up from the database, NOT from client input,
+ * which prevents attackers from bypassing the check by omitting organizationId.
+ */
+export const checkNetworkAccess = async (
+	ctx: {
+		session: { user: { id: string } };
+		prisma: {
+			network: {
+				findUnique: (args: {
+					where: { nwid: string };
+					select: { authorId: boolean; organizationId: boolean };
+				}) => Promise<{ authorId: string; organizationId: string | null } | null>;
+			};
+			userOrganizationRole: {
+				findFirst: (args: unknown) => Promise<unknown>;
+			};
+		};
+	},
+	nwid: string,
+	minimumRequiredRole: Role,
+) => {
+	const network = await ctx.prisma.network.findUnique({
+		where: { nwid },
+		select: { authorId: true, organizationId: true },
+	});
+
+	if (!network) {
+		return throwError("Network not found!", "NOT_FOUND");
+	}
+
+	// Organization network: check user has the required role in the organization
+	if (network.organizationId) {
+		await checkUserOrganizationRole({
+			ctx,
+			organizationId: network.organizationId,
+			minimumRequiredRole,
+		});
+		return;
+	}
+
+	// Personal network: only the author (owner) can access
+	if (network.authorId !== ctx.session.user.id) {
+		return throwError("You do not have access to this network!");
+	}
+};


### PR DESCRIPTION
- Add reusable `checkNetworkAccess` helper that verifies network ownership or org membership via database lookup
- Replace conditional auth checks across network and member router endpoints with the new helper
- Add missing org membership check to `generateInviteLink` and `markMessagesAsRead`
- Add device ownership check to `deleteUserDevice`
- Removed getOrgWebhooks, dead code