### PR TITLE
Fixes a typo that prevented the German translation from loading in planet sectin

### DIFF
--- a/src/locales/de/common.json
+++ b/src/locales/de/common.json
@@ -762,7 +762,7 @@
 				"submit_empty_field_default": "Lassen Sie das Feld leer, um die Standardeinstellung zu verwenden.",
 				"isUsingEnvVariablesAlert": "Die Umgebungsvariable <span>ZT_ADDR</span> oder <span>ZT_SECRET</span> hat Vorrang und überschreibt alle über die Benutzeroberfläche vorgenommenen URL-Änderungen. Um die entsprechenden Felder über die Benutzeroberfläche zu aktualisieren, müssen Sie zunächst die Umgebungsvariablen <span>ZT_ADDR</span> oder <span>ZT_SECRET</span> entfernen."
 			},
-			"gene/ratePlanet": {
+			"generatePlanet": {
 				"updatePlanetWarning": "Durch das Aktualisieren der Planet-Datei wird die Kernstruktur Ihres ZeroTier-Netzwerks geändert, was sich auf Routen, Flexibilität und möglicherweise auch auf die Verfügbarkeit auswirkt. Gehen Sie mit Bedacht vor und machen Sie sich die Auswirkungen bewusst.",
 				"customPlanetInUse": "Benutzerdefinierter Planet wird bereits verwendet!",
 				"customPortIsInUse": "Hinweis! Port ist benutzerdefiniert",


### PR DESCRIPTION
This pull request fixes an issue where a simple typo prevented the German translation from loading correctly in the **Custom Planet** section.
The typo caused the translation key to be referenced incorrectly, resulting in missing or fallback text for German‑speaking users.
Changes included:

- Corrected the misspelled translation key
- Verified that the German localization now loads as expected in the affected section

This ensures proper localization behavior and improves overall user experience for German users.