### PR TITLE
Enhance network member schema and update POST method to include new fields

### DIFF
--- a/docs/docs/Rest Api/Organization/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Organization/_source/networkMember.yml
@@ -130,32 +130,32 @@ paths:
                 authorized:
                   type: boolean
                   description: Authorization status of the member
-                  activeBridge:
-                    type: boolean
-                    description: Active bridge status
-                  capabilities:
-                    type: integer
-                    description: Capabilities of the member
-                  ipAssignments:
-                    type: array
+                activeBridge:
+                  type: boolean
+                  description: Active bridge status
+                capabilities:
+                  type: integer
+                  description: Capabilities of the member
+                ipAssignments:
+                  type: array
+                  items:
+                    type: string
+                    description: IP assignments of the member
+                noAutoAssignIps:
+                  type: boolean
+                  description: No auto-assign IPs status
+                ssoExempt:
+                  type: boolean
+                  description: SSO exemption status
+                tags:
+                  type: array
+                  items:
+                    type: tuple
                     items:
-                      type: string
-                      description: IP assignments of the member
-                  noAutoAssignIps:
-                    type: boolean
-                    description: No auto-assign IPs status
-                  ssoExempt:
-                    type: boolean
-                    description: SSO exemption status
-                  tags:
-                    type: array
-                    items:
-                      type: tuple
-                      items:
-                        - type: string
-                          description: Tag key
-                        - type: string
-                          description: Tag value
+                      - type: string
+                        description: Tag key
+                      - type: string
+                        description: Tag value
               # required:
               #   - name
               #   - authorized

--- a/docs/docs/Rest Api/Organization/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Organization/_source/networkMember.yml
@@ -130,6 +130,32 @@ paths:
                 authorized:
                   type: boolean
                   description: Authorization status of the member
+                  activeBridge:
+                    type: boolean
+                    description: Active bridge status
+                  capabilities:
+                    type: integer
+                    description: Capabilities of the member
+                  ipAssignments:
+                    type: array
+                    items:
+                      type: string
+                      description: IP assignments of the member
+                  noAutoAssignIps:
+                    type: boolean
+                    description: No auto-assign IPs status
+                  ssoExempt:
+                    type: boolean
+                    description: SSO exemption status
+                  tags:
+                    type: array
+                    items:
+                      type: tuple
+                      items:
+                        - type: string
+                          description: Tag key
+                        - type: string
+                          description: Tag value
               # required:
               #   - name
               #   - authorized

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
@@ -6,6 +6,12 @@ export const PostBodySchema = z
 		name: z.string().optional(),
 		description: z.string().optional(),
 		authorized: z.boolean().optional(),
+		activeBridge: z.boolean().optional(),
+		capabilities: z.array(z.string()).optional(),
+		ipAssignments: z.array(z.string()).optional(),
+		noAutoAssignIps: z.boolean().optional(),
+		ssoExempt: z.boolean().optional(),
+		tags: z.array(z.string()).optional(),
 	})
 	.strict();
 

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
@@ -7,11 +7,11 @@ export const PostBodySchema = z
 		description: z.string().optional(),
 		authorized: z.boolean().optional(),
 		activeBridge: z.boolean().optional(),
-		capabilities: z.array(z.string()).optional(),
+		capabilities: z.array(z.number()).optional(),
 		ipAssignments: z.array(z.string()).optional(),
 		noAutoAssignIps: z.boolean().optional(),
 		ssoExempt: z.boolean().optional(),
-		tags: z.array(z.string()).optional(),
+		tags: z.array(z.tuple([z.string(), z.string()])).optional(),
 	})
 	.strict();
 

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
@@ -11,7 +11,7 @@ export const PostBodySchema = z
 		ipAssignments: z.array(z.string()).optional(),
 		noAutoAssignIps: z.boolean().optional(),
 		ssoExempt: z.boolean().optional(),
-		tags: z.array(z.tuple([z.string(), z.string()])).optional(),
+		tags: z.array(z.tuple([z.number(), z.number()])).optional(),
 	})
 	.strict();
 

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -68,6 +68,12 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 			const updateableFields = {
 				name: { type: "string", destinations: ["database"] },
 				authorized: { type: "boolean", destinations: ["controller"] },
+				activeBridge: { type: "boolean", destinations: ["controller"] },
+				capabilities: { type: "array", destinations: ["controller"] },
+				ipAssignments: { type: "array", destinations: ["controller"] },
+				noAutoAssignIps: { type: "boolean", destinations: ["controller"] },
+				ssoExempt: { type: "boolean", destinations: ["controller"] },
+				tags: { type: "array", destinations: ["controller"] },
 			};
 
 			const databasePayload: Partial<network_members> = {};


### PR DESCRIPTION
Enhance network member schema and update POST method to include new fields

- Added optional fields to the PostBodySchema: activeBridge, capabilities, ipAssignments, noAutoAssignIps, ssoExempt, and tags.
- Updated the POST_orgUpdateNetworkMember function to allow these new fields for network member updates.

Resolves: #851 