### PR TITLE
Update flowRules to flowRule in NetworkSchema.yml for consistency

### DIFF
--- a/docs/docs/Rest Api/_schema/NetworkSchema.yml
+++ b/docs/docs/Rest Api/_schema/NetworkSchema.yml
@@ -148,7 +148,7 @@ UpdateNetworkShema:
           via:
             type: string
             nullable: true
-    flowRules:
+    flowRule:
       type: string
       default: "drop not ethertype ipv4 and not ethertype arp and not ethertype ipv6; accept;"
     v4AssignMode:


### PR DESCRIPTION
### Summary
This PR fixes a documentation inconsistency in the network schema by renaming flowRules to flowRule.

The previous field name (flowRules) did not match the actual API field usage, which could cause confusion for API consumers. This update ensures the documentation reflects the correct field name consistently.

### Changes
Updated docs/docs/Rest Api/_schema/NetworkSchema.yml
Renamed documented property:
flowRules → flowRule

### Why
Keeping the documented schema aligned with the real API contract helps prevent integration errors and improves clarity for users of the REST API.