### PR TITLE
Harden better-auth migration: OAuth, password sync, security checks

### DIFF
--- a/jest.api.config.ts
+++ b/jest.api.config.ts
@@ -38,7 +38,7 @@ const jestConfig: JestConfigWithTsJest = {
 	...filesConfig,
 	...moduleConfig,
 	...testConfig,
-	modulePathIgnorePatterns: ["<rootDir>/docs/"],
+	modulePathIgnorePatterns: ["<rootDir>/docs/", "<rootDir>/.claude/"],
 };
 
 const createJestConfig = nextJest(nextConfig);

--- a/jest.pages.config.ts
+++ b/jest.pages.config.ts
@@ -17,7 +17,7 @@ const jestConfig: JestConfigWithTsJest = {
   },
   setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testEnvironment: "jest-fixed-jsdom",
-  modulePathIgnorePatterns: ["<rootDir>/docs/"],
+  modulePathIgnorePatterns: ["<rootDir>/docs/", "<rootDir>/.claude/"],
   moduleNameMapper: {
     "^~/(.*)$": "<rootDir>/src/$1",
     "^lib/(.*)$": "<rootDir>/common/$1",

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,19 +30,5 @@ const config = {
 			},
 		];
 	},
-	async rewrites() {
-		// Legacy OAuth callback URL preserved for backwards compatibility.
-		// Pre-better-auth ztnet docs instructed users to register
-		// `${NEXTAUTH_URL}/api/auth/callback/oauth` with their IdP. better-auth's
-		// genericOAuth plugin serves the callback at `/api/auth/oauth2/callback/:providerId`,
-		// so we forward the legacy path internally. The redirect_uri sent to the IdP is
-		// pinned to the legacy path in `src/lib/auth.ts` (`legacyOAuthRedirectURI`).
-		return [
-			{
-				source: "/api/auth/callback/oauth",
-				destination: "/api/auth/oauth2/callback/oauth",
-			},
-		];
-	},
 };
 export default config;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -30,5 +30,19 @@ const config = {
 			},
 		];
 	},
+	async rewrites() {
+		// Legacy OAuth callback URL preserved for backwards compatibility.
+		// Pre-better-auth ztnet docs instructed users to register
+		// `${NEXTAUTH_URL}/api/auth/callback/oauth` with their IdP. better-auth's
+		// genericOAuth plugin serves the callback at `/api/auth/oauth2/callback/:providerId`,
+		// so we forward the legacy path internally. The redirect_uri sent to the IdP is
+		// pinned to the legacy path in `src/lib/auth.ts` (`legacyOAuthRedirectURI`).
+		return [
+			{
+				source: "/api/auth/callback/oauth",
+				destination: "/api/auth/oauth2/callback/oauth",
+			},
+		];
+	},
 };
 export default config;

--- a/src/__tests__/components/oauthLogin.test.tsx
+++ b/src/__tests__/components/oauthLogin.test.tsx
@@ -5,12 +5,12 @@ import { toast } from "react-hot-toast";
 import OAuthLogin from "~/components/auth/oauthLogin";
 import enTranslation from "~/locales/en/common.json";
 
-const mockSignInOAuth2 = jest.fn();
+const mockSignInSocial = jest.fn();
 
 jest.mock("~/lib/authClient", () => ({
 	authClient: {
 		signIn: {
-			oauth2: (...args: unknown[]) => mockSignInOAuth2(...args),
+			social: (...args: unknown[]) => mockSignInSocial(...args),
 		},
 	},
 }));
@@ -28,7 +28,7 @@ const renderWithIntl = (ui: React.ReactElement) =>
 
 describe("OAuthLogin", () => {
 	beforeEach(() => {
-		mockSignInOAuth2.mockReset();
+		mockSignInSocial.mockReset();
 		(toast.error as jest.Mock).mockReset();
 	});
 
@@ -37,11 +37,13 @@ describe("OAuthLogin", () => {
 		expect(container.firstChild).toBeNull();
 	});
 
-	it("calls authClient.signIn.oauth2 with providerId 'oauth'", async () => {
-		// Regression guard: under the better-auth migration this MUST be
-		// `signIn.oauth2({ providerId: ... })`. Using `signIn.social({ provider })`
-		// (the next-auth shape) silently 404s the genericOAuth plugin route.
-		mockSignInOAuth2.mockResolvedValue({
+	it("calls authClient.signIn.social with provider 'oauth'", async () => {
+		// Pinned to `signIn.social` (NOT `signIn.oauth2`) so the IdP redirect URI
+		// stays at `${baseURL}/api/auth/callback/oauth` — the URL ztnet has always
+		// shipped in its docs and that users have registered with their IdP.
+		// The genericOAuth plugin's init() injects the provider into
+		// `socialProviders`, so PKCE/mapProfileToUser/discoveryUrl all still apply.
+		mockSignInSocial.mockResolvedValue({
 			data: { url: "https://idp.example/authorize" },
 			error: null,
 		});
@@ -49,36 +51,33 @@ describe("OAuthLogin", () => {
 		renderWithIntl(<OAuthLogin oauthEnabled={true} />);
 		await userEvent.click(screen.getByRole("button"));
 
-		expect(mockSignInOAuth2).toHaveBeenCalledTimes(1);
-		expect(mockSignInOAuth2).toHaveBeenCalledWith(
+		expect(mockSignInSocial).toHaveBeenCalledTimes(1);
+		expect(mockSignInSocial).toHaveBeenCalledWith(
 			expect.objectContaining({
-				providerId: "oauth",
+				provider: "oauth",
 				callbackURL: "/network",
 			}),
 		);
-		expect(mockSignInOAuth2).not.toHaveBeenCalledWith(
-			expect.objectContaining({ provider: expect.anything() }),
-		);
 	});
 
-	it("surfaces an error returned by signIn.oauth2", async () => {
-		mockSignInOAuth2.mockResolvedValue({
+	it("surfaces an error returned by signIn.social", async () => {
+		mockSignInSocial.mockResolvedValue({
 			data: null,
-			error: { message: "Provider config not found" },
+			error: { message: "Provider not found" },
 		});
 
 		renderWithIntl(<OAuthLogin oauthEnabled={true} />);
 		await userEvent.click(screen.getByRole("button"));
 
 		await waitFor(() => {
-			expect(toast.error).toHaveBeenCalledWith("Provider config not found", {
+			expect(toast.error).toHaveBeenCalledWith("Provider not found", {
 				duration: 10000,
 			});
 		});
 	});
 
-	it("falls back to a generic message when signIn.oauth2 throws", async () => {
-		mockSignInOAuth2.mockRejectedValue(new Error("network down"));
+	it("falls back to a generic message when signIn.social throws", async () => {
+		mockSignInSocial.mockRejectedValue(new Error("network down"));
 
 		renderWithIntl(<OAuthLogin oauthEnabled={true} />);
 		await userEvent.click(screen.getByRole("button"));

--- a/src/__tests__/components/oauthLogin.test.tsx
+++ b/src/__tests__/components/oauthLogin.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { NextIntlClientProvider } from "next-intl";
+import { toast } from "react-hot-toast";
+import OAuthLogin from "~/components/auth/oauthLogin";
+import enTranslation from "~/locales/en/common.json";
+
+const mockSignInOAuth2 = jest.fn();
+
+jest.mock("~/lib/authClient", () => ({
+	authClient: {
+		signIn: {
+			oauth2: (...args: unknown[]) => mockSignInOAuth2(...args),
+		},
+	},
+}));
+
+jest.mock("react-hot-toast", () => ({
+	toast: { error: jest.fn() },
+}));
+
+const renderWithIntl = (ui: React.ReactElement) =>
+	render(
+		<NextIntlClientProvider locale="en" messages={enTranslation}>
+			{ui}
+		</NextIntlClientProvider>,
+	);
+
+describe("OAuthLogin", () => {
+	beforeEach(() => {
+		mockSignInOAuth2.mockReset();
+		(toast.error as jest.Mock).mockReset();
+	});
+
+	it("returns null when oauthEnabled is false", () => {
+		const { container } = renderWithIntl(<OAuthLogin oauthEnabled={false} />);
+		expect(container.firstChild).toBeNull();
+	});
+
+	it("calls authClient.signIn.oauth2 with providerId 'oauth'", async () => {
+		// Regression guard: under the better-auth migration this MUST be
+		// `signIn.oauth2({ providerId: ... })`. Using `signIn.social({ provider })`
+		// (the next-auth shape) silently 404s the genericOAuth plugin route.
+		mockSignInOAuth2.mockResolvedValue({
+			data: { url: "https://idp.example/authorize" },
+			error: null,
+		});
+
+		renderWithIntl(<OAuthLogin oauthEnabled={true} />);
+		await userEvent.click(screen.getByRole("button"));
+
+		expect(mockSignInOAuth2).toHaveBeenCalledTimes(1);
+		expect(mockSignInOAuth2).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerId: "oauth",
+				callbackURL: "/network",
+			}),
+		);
+		expect(mockSignInOAuth2).not.toHaveBeenCalledWith(
+			expect.objectContaining({ provider: expect.anything() }),
+		);
+	});
+
+	it("surfaces an error returned by signIn.oauth2", async () => {
+		mockSignInOAuth2.mockResolvedValue({
+			data: null,
+			error: { message: "Provider config not found" },
+		});
+
+		renderWithIntl(<OAuthLogin oauthEnabled={true} />);
+		await userEvent.click(screen.getByRole("button"));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith("Provider config not found", {
+				duration: 10000,
+			});
+		});
+	});
+
+	it("falls back to a generic message when signIn.oauth2 throws", async () => {
+		mockSignInOAuth2.mockRejectedValue(new Error("network down"));
+
+		renderWithIntl(<OAuthLogin oauthEnabled={true} />);
+		await userEvent.click(screen.getByRole("button"));
+
+		await waitFor(() => {
+			expect(toast.error).toHaveBeenCalledWith("Unexpected error occurred", {
+				duration: 10000,
+			});
+		});
+	});
+});

--- a/src/__tests__/pages/auth/signin.test.tsx
+++ b/src/__tests__/pages/auth/signin.test.tsx
@@ -190,9 +190,12 @@ describe("LoginPage", () => {
 		});
 	});
 
-	it("handles OAuth sign-in via the genericOAuth plugin (signIn.oauth2)", async () => {
-		// genericOAuth plugin requires `signIn.oauth2({ providerId })`, not
-		// `signIn.social({ provider })`. Calling the wrong method silently 404s.
+	it("handles OAuth sign-in via signIn.social (preserves legacy callback URL)", async () => {
+		// We use `signIn.social` (not `signIn.oauth2`) so the IdP callback URL
+		// stays at `/api/auth/callback/oauth` — the URL documented at
+		// https://ztnet.network/authentication/oauth and registered in every
+		// existing IdP. The genericOAuth plugin still drives the flow because
+		// its init() injects the provider into `socialProviders`.
 		mockSignInSocial.mockResolvedValue({
 			data: { url: "https://idp.example/auth" },
 			error: null,
@@ -206,7 +209,7 @@ describe("LoginPage", () => {
 
 		expect(mockSignInSocial).toHaveBeenCalledWith(
 			expect.objectContaining({
-				providerId: "oauth",
+				provider: "oauth",
 				callbackURL: "/network",
 			}),
 		);

--- a/src/__tests__/pages/auth/signin.test.tsx
+++ b/src/__tests__/pages/auth/signin.test.tsx
@@ -9,17 +9,17 @@ import { ErrorCode } from "~/utils/errorCode";
 import * as reactHotToast from "react-hot-toast";
 
 const mockSignInEmail = jest.fn();
-const mockSignInSocial = jest.fn();
+const mockSignInOAuth2 = jest.fn();
 
 jest.mock("~/lib/authClient", () => ({
 	authClient: {
 		signIn: {
 			email: (...args) => mockSignInEmail(...args),
-			social: (...args) => mockSignInSocial(...args),
+			oauth2: (...args) => mockSignInOAuth2(...args),
 		},
 	},
 	signIn: {
-		social: (...args) => mockSignInSocial(...args),
+		oauth2: (...args) => mockSignInOAuth2(...args),
 	},
 }));
 jest.mock("~/server/db", () => ({
@@ -85,7 +85,7 @@ describe("LoginPage", () => {
 	beforeEach(() => {
 		queryClient = new QueryClient();
 		mockSignInEmail.mockReset();
-		mockSignInSocial.mockReset();
+		mockSignInOAuth2.mockReset();
 		jest.clearAllMocks();
 	});
 
@@ -190,17 +190,42 @@ describe("LoginPage", () => {
 		});
 	});
 
-	it("handles OAuth sign-in", async () => {
+	it("handles OAuth sign-in via the genericOAuth plugin (signIn.oauth2)", async () => {
+		// genericOAuth plugin requires `signIn.oauth2({ providerId })`, not
+		// `signIn.social({ provider })`. Calling the wrong method silently 404s.
+		mockSignInOAuth2.mockResolvedValue({
+			data: { url: "https://idp.example/auth" },
+			error: null,
+		});
+
 		renderLoginPage();
-		// Wait for the button to be displayed
 		await waitFor(() => screen.getByRole("button", { name: /Sign in with OAuth/i }));
 
 		const oauthButton = screen.getByRole("button", { name: /Sign in with OAuth/i });
 		await userEvent.click(oauthButton);
 
-		expect(mockSignInSocial).toHaveBeenCalledWith({
-			provider: "oauth",
-			callbackURL: "/network",
+		expect(mockSignInOAuth2).toHaveBeenCalledWith(
+			expect.objectContaining({
+				providerId: "oauth",
+				callbackURL: "/network",
+			}),
+		);
+	});
+
+	it("surfaces OAuth errors from the better-auth client", async () => {
+		mockSignInOAuth2.mockResolvedValue({
+			data: null,
+			error: { message: "Provider not found" },
+		});
+
+		renderLoginPage();
+		await waitFor(() => screen.getByRole("button", { name: /Sign in with OAuth/i }));
+		await userEvent.click(screen.getByRole("button", { name: /Sign in with OAuth/i }));
+
+		await waitFor(() => {
+			expect(reactHotToast.toast.error).toHaveBeenCalledWith("Provider not found", {
+				duration: 10000,
+			});
 		});
 	});
 

--- a/src/__tests__/pages/auth/signin.test.tsx
+++ b/src/__tests__/pages/auth/signin.test.tsx
@@ -9,17 +9,17 @@ import { ErrorCode } from "~/utils/errorCode";
 import * as reactHotToast from "react-hot-toast";
 
 const mockSignInEmail = jest.fn();
-const mockSignInOAuth2 = jest.fn();
+const mockSignInSocial = jest.fn();
 
 jest.mock("~/lib/authClient", () => ({
 	authClient: {
 		signIn: {
 			email: (...args) => mockSignInEmail(...args),
-			oauth2: (...args) => mockSignInOAuth2(...args),
+			social: (...args) => mockSignInSocial(...args),
 		},
 	},
 	signIn: {
-		oauth2: (...args) => mockSignInOAuth2(...args),
+		social: (...args) => mockSignInSocial(...args),
 	},
 }));
 jest.mock("~/server/db", () => ({
@@ -85,7 +85,7 @@ describe("LoginPage", () => {
 	beforeEach(() => {
 		queryClient = new QueryClient();
 		mockSignInEmail.mockReset();
-		mockSignInOAuth2.mockReset();
+		mockSignInSocial.mockReset();
 		jest.clearAllMocks();
 	});
 
@@ -193,7 +193,7 @@ describe("LoginPage", () => {
 	it("handles OAuth sign-in via the genericOAuth plugin (signIn.oauth2)", async () => {
 		// genericOAuth plugin requires `signIn.oauth2({ providerId })`, not
 		// `signIn.social({ provider })`. Calling the wrong method silently 404s.
-		mockSignInOAuth2.mockResolvedValue({
+		mockSignInSocial.mockResolvedValue({
 			data: { url: "https://idp.example/auth" },
 			error: null,
 		});
@@ -204,7 +204,7 @@ describe("LoginPage", () => {
 		const oauthButton = screen.getByRole("button", { name: /Sign in with OAuth/i });
 		await userEvent.click(oauthButton);
 
-		expect(mockSignInOAuth2).toHaveBeenCalledWith(
+		expect(mockSignInSocial).toHaveBeenCalledWith(
 			expect.objectContaining({
 				providerId: "oauth",
 				callbackURL: "/network",
@@ -213,7 +213,7 @@ describe("LoginPage", () => {
 	});
 
 	it("surfaces OAuth errors from the better-auth client", async () => {
-		mockSignInOAuth2.mockResolvedValue({
+		mockSignInSocial.mockResolvedValue({
 			data: null,
 			error: { message: "Provider not found" },
 		});

--- a/src/components/auth/oauthLogin.tsx
+++ b/src/components/auth/oauthLogin.tsx
@@ -17,10 +17,19 @@ const OAuthLogin: React.FC<OAuthLoginProps> = ({ oauthEnabled = true }) => {
 	const oAuthHandler = async () => {
 		setLoading(true);
 		try {
-			await authClient.signIn.social({
-				provider: "oauth",
+			// genericOAuth plugin uses `signIn.oauth2`, not `signIn.social`.
+			// `signIn.social` is reserved for the built-in social providers
+			// (google, github, etc.) and would 404 here.
+			const { error } = await authClient.signIn.oauth2({
+				providerId: "oauth",
 				callbackURL: "/network",
+				errorCallbackURL: "/auth/login",
 			});
+			if (error) {
+				toast.error(error.message || "Unexpected error occurred", {
+					duration: 10000,
+				});
+			}
 		} catch (_error) {
 			toast.error("Unexpected error occurred", { duration: 10000 });
 		} finally {

--- a/src/components/auth/oauthLogin.tsx
+++ b/src/components/auth/oauthLogin.tsx
@@ -17,11 +17,14 @@ const OAuthLogin: React.FC<OAuthLoginProps> = ({ oauthEnabled = true }) => {
 	const oAuthHandler = async () => {
 		setLoading(true);
 		try {
-			// genericOAuth plugin uses `signIn.oauth2`, not `signIn.social`.
-			// `signIn.social` is reserved for the built-in social providers
-			// (google, github, etc.) and would 404 here.
-			const { error } = await authClient.signIn.oauth2({
-				providerId: "oauth",
+			// We deliberately use `signIn.social` (NOT `signIn.oauth2`) so the
+			// callback URL stays `${baseURL}/api/auth/callback/oauth` — the same
+			// path documented at https://ztnet.network/authentication/oauth and
+			// already registered in every existing IdP config. The genericOAuth
+			// plugin injects its provider into `socialProviders` at init time, so
+			// this routes through the plugin (PKCE, mapProfileToUser, etc. all apply).
+			const { error } = await authClient.signIn.social({
+				provider: "oauth",
 				callbackURL: "/network",
 				errorCallbackURL: "/auth/login",
 			});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -59,6 +59,49 @@ export function isOAuthAllowNewUsers(): boolean {
 	return process.env.OAUTH_ALLOW_NEW_USERS?.toLowerCase() !== "false";
 }
 
+/**
+ * Maps an OAuth provider's profile object into ztnet's user shape. The fallback
+ * chain matters because the documented providers expose different field names:
+ * - GitHub uses `login` for username, `email` may be null on private profiles
+ * - Discord/Authentik use `username`
+ * - Keycloak/Azure AD use `name`
+ * - Profile pictures live under `picture` (OIDC), `avatar_url` (GitHub), or
+ *   `image_url` (some providers).
+ *
+ * Exported for unit testing.
+ */
+export function mapOAuthProfileToUser(profile: Record<string, unknown>): {
+	name: string;
+	email: string | undefined;
+	image: string | undefined;
+} {
+	const email = typeof profile.email === "string" ? (profile.email as string) : undefined;
+	const pickStr = (key: string): string | undefined =>
+		typeof profile[key] === "string" ? (profile[key] as string) : undefined;
+	return {
+		name:
+			pickStr("name") ||
+			pickStr("login") ||
+			pickStr("username") ||
+			email?.split("@")[0] ||
+			"OAuth User",
+		email,
+		image: pickStr("picture") || pickStr("avatar_url") || pickStr("image_url"),
+	};
+}
+
+/**
+ * Splits OAUTH_SCOPE into the array that better-auth's genericOAuth expects.
+ * Defaults to the OIDC trio. Trims whitespace and drops empty tokens so that
+ * `OAUTH_SCOPE="  openid  profile email "` doesn't yield empty strings.
+ *
+ * Exported for unit testing.
+ */
+export function parseOAuthScopes(): string[] {
+	const raw = process.env.OAUTH_SCOPE || "openid profile email";
+	return raw.split(/\s+/).filter(Boolean);
+}
+
 function buildGenericOAuthPlugin() {
 	if (!process.env.OAUTH_ID || !process.env.OAUTH_SECRET) {
 		return [];
@@ -75,7 +118,7 @@ function buildGenericOAuthPlugin() {
 					authorizationUrl: process.env.OAUTH_AUTHORIZATION_URL || undefined,
 					tokenUrl: process.env.OAUTH_ACCESS_TOKEN_URL || undefined,
 					userInfoUrl: process.env.OAUTH_USER_INFO || undefined,
-					scopes: (process.env.OAUTH_SCOPE || "openid profile email").split(" "),
+					scopes: parseOAuthScopes(),
 					// PKCE was enforced under next-auth (`checks: ["state","pkce"]`).
 					// better-auth's genericOAuth plugin defaults pkce to false, so we re-enable it.
 					pkce: true,
@@ -84,26 +127,24 @@ function buildGenericOAuthPlugin() {
 					// would otherwise be told to redirect through better-auth's own
 					// `/oauth2/callback/oauth` path. See `oauthCallbackURL` above.
 					redirectURI: oauthCallbackURL(),
-					mapProfileToUser: (profile) => ({
-						name:
-							profile.name ||
-							profile.login ||
-							profile.username ||
-							profile.email?.split("@")[0] ||
-							"OAuth User",
-						email: profile.email,
-						image: profile.picture || profile.avatar_url || profile.image_url,
-					}),
+					mapProfileToUser: (profile) =>
+						mapOAuthProfileToUser(profile as Record<string, unknown>),
 				},
 			],
 		}),
 	];
 }
 
-// ── Before hook: cooldown + 2FA enforcement for credential sign-in only ──
-// Active/expiry checks live in `databaseHooks.session.create.before` so they cover
-// OAuth sign-in too. Password verification is delegated to better-auth (Account.password).
-const beforeHook = createAuthMiddleware(async (ctx) => {
+/**
+ * The credential sign-in pre-flight: cooldown + failed-attempt tracking +
+ * credential-Account backfill + TOTP. Extracted as a plain async function so
+ * it can be unit-tested directly; the production wiring is the `beforeHook`
+ * createAuthMiddleware below.
+ *
+ * Exported for unit testing.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: better-auth's MiddlewareContext is internal
+export async function runBeforeAuthHook(ctx: any): Promise<void> {
 	// Defense-in-depth: if OAUTH_EXCLUSIVE_LOGIN is on, refuse credential endpoints
 	// even if the UI fails to hide them.
 	if (
@@ -224,6 +265,10 @@ const beforeHook = createAuthMiddleware(async (ctx) => {
 			throw new APIError("UNAUTHORIZED", { message: "incorrect-two-factor-code" });
 		}
 	}
+}
+
+const beforeHook = createAuthMiddleware(async (ctx) => {
+	await runBeforeAuthHook(ctx);
 });
 
 function getIpFromHeaders(headers: Headers | null | undefined): string {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -21,13 +21,34 @@ const COOLDOWN_PERIOD = 1 * 60 * 1000; // 1 minute
 
 // We expose the generic OAuth provider as id "oauth" — the same id ztnet has
 // always shipped, and the one referenced in `signIn.social({ provider: "oauth" })`.
-// Sticking with `signIn.social` (rather than `signIn.oauth2`) keeps the callback
-// URL at the documented `${NEXTAUTH_URL}/api/auth/callback/oauth`, so existing IdP
-// registrations don't have to be re-pointed when upgrading from next-auth.
-// The genericOAuth plugin still drives the flow — at init time it injects this
-// config into `socialProviders`, so PKCE / mapProfileToUser / discoveryUrl all
-// apply through the `signIn.social` path too.
+// Sticking with `signIn.social` (rather than `signIn.oauth2`) routes through
+// better-auth's `/callback/:id` endpoint, which lives at the documented
+// `${NEXTAUTH_URL}/api/auth/callback/oauth` path — so existing IdP registrations
+// keep working. The genericOAuth plugin still drives the flow: at init time it
+// injects this config into `socialProviders`, so PKCE / mapProfileToUser /
+// discoveryUrl all apply through the `signIn.social` path too.
 export const OAUTH_PROVIDER_ID = "oauth";
+
+/**
+ * Canonical OAuth callback URL.
+ *
+ * IMPORTANT — must match the URL documented at
+ * https://ztnet.network/authentication/oauth and registered with the IdP.
+ *
+ * Without this, the genericOAuth plugin's injected `createAuthorizationURL` falls
+ * back to `${ctx.baseURL}/oauth2/callback/oauth` (verified at
+ * `node_modules/better-auth/dist/plugins/generic-oauth/index.mjs:62`), which
+ * does NOT match the documented redirect URI. Setting `c.redirectURI` makes
+ * core's `createAuthorizationURL` use it for both the authorize-URL `redirect_uri`
+ * parameter and the token-exchange request body
+ * (see `@better-auth/core/dist/oauth2/create-authorization-url.mjs:11` and
+ * `validate-authorization-code.mjs:35` — both pick `options.redirectURI` first).
+ */
+export function oauthCallbackURL(): string | undefined {
+	const base = process.env.NEXTAUTH_URL;
+	if (!base) return undefined;
+	return `${base.replace(/\/$/, "")}/api/auth/callback/${OAUTH_PROVIDER_ID}`;
+}
 
 export function isOAuthExclusiveLogin(): boolean {
 	return process.env.OAUTH_EXCLUSIVE_LOGIN?.toLowerCase() === "true";
@@ -58,6 +79,11 @@ function buildGenericOAuthPlugin() {
 					// PKCE was enforced under next-auth (`checks: ["state","pkce"]`).
 					// better-auth's genericOAuth plugin defaults pkce to false, so we re-enable it.
 					pkce: true,
+					// Pin the redirect URI to the URL ztnet has always documented at
+					// https://ztnet.network/authentication/oauth — `signIn.social`
+					// would otherwise be told to redirect through better-auth's own
+					// `/oauth2/callback/oauth` path. See `oauthCallbackURL` above.
+					redirectURI: oauthCallbackURL(),
 					mapProfileToUser: (profile) => ({
 						name:
 							profile.name ||

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,19 +19,15 @@ import { randomBytes } from "crypto";
 const MAX_FAILED_ATTEMPTS = 5;
 const COOLDOWN_PERIOD = 1 * 60 * 1000; // 1 minute
 
-// Backwards-compat callback URL.
-// Pre-better-auth ztnet docs (https://ztnet.network/authentication/oauth) instructed
-// users to register `${NEXTAUTH_URL}/api/auth/callback/oauth` with their IdP.
-// better-auth's genericOAuth plugin defaults to `${baseURL}/oauth2/callback/:providerId`,
-// which would break every existing install. We pin redirectURI to the legacy path here
-// and rely on a Next.js rewrite (see next.config.mjs) to forward the legacy path into
-// better-auth's actual callback handler.
+// We expose the generic OAuth provider as id "oauth" — the same id ztnet has
+// always shipped, and the one referenced in `signIn.social({ provider: "oauth" })`.
+// Sticking with `signIn.social` (rather than `signIn.oauth2`) keeps the callback
+// URL at the documented `${NEXTAUTH_URL}/api/auth/callback/oauth`, so existing IdP
+// registrations don't have to be re-pointed when upgrading from next-auth.
+// The genericOAuth plugin still drives the flow — at init time it injects this
+// config into `socialProviders`, so PKCE / mapProfileToUser / discoveryUrl all
+// apply through the `signIn.social` path too.
 export const OAUTH_PROVIDER_ID = "oauth";
-export function legacyOAuthRedirectURI(): string | undefined {
-	const base = process.env.NEXTAUTH_URL;
-	if (!base) return undefined;
-	return `${base.replace(/\/$/, "")}/api/auth/callback/${OAUTH_PROVIDER_ID}`;
-}
 
 export function isOAuthExclusiveLogin(): boolean {
 	return process.env.OAUTH_EXCLUSIVE_LOGIN?.toLowerCase() === "true";
@@ -62,9 +58,6 @@ function buildGenericOAuthPlugin() {
 					// PKCE was enforced under next-auth (`checks: ["state","pkce"]`).
 					// better-auth's genericOAuth plugin defaults pkce to false, so we re-enable it.
 					pkce: true,
-					// Pin redirect URI to the legacy path so existing IdP registrations keep working.
-					// See `legacyOAuthRedirectURI` and the rewrite in `next.config.mjs`.
-					redirectURI: legacyOAuthRedirectURI(),
 					mapProfileToUser: (profile) => ({
 						name:
 							profile.name ||

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -19,6 +19,29 @@ import { randomBytes } from "crypto";
 const MAX_FAILED_ATTEMPTS = 5;
 const COOLDOWN_PERIOD = 1 * 60 * 1000; // 1 minute
 
+// Backwards-compat callback URL.
+// Pre-better-auth ztnet docs (https://ztnet.network/authentication/oauth) instructed
+// users to register `${NEXTAUTH_URL}/api/auth/callback/oauth` with their IdP.
+// better-auth's genericOAuth plugin defaults to `${baseURL}/oauth2/callback/:providerId`,
+// which would break every existing install. We pin redirectURI to the legacy path here
+// and rely on a Next.js rewrite (see next.config.mjs) to forward the legacy path into
+// better-auth's actual callback handler.
+export const OAUTH_PROVIDER_ID = "oauth";
+export function legacyOAuthRedirectURI(): string | undefined {
+	const base = process.env.NEXTAUTH_URL;
+	if (!base) return undefined;
+	return `${base.replace(/\/$/, "")}/api/auth/callback/${OAUTH_PROVIDER_ID}`;
+}
+
+export function isOAuthExclusiveLogin(): boolean {
+	return process.env.OAUTH_EXCLUSIVE_LOGIN?.toLowerCase() === "true";
+}
+
+export function isOAuthAllowNewUsers(): boolean {
+	// Default true (matches pre-migration behavior in publicRouter/settingsRouter).
+	return process.env.OAUTH_ALLOW_NEW_USERS?.toLowerCase() !== "false";
+}
+
 function buildGenericOAuthPlugin() {
 	if (!process.env.OAUTH_ID || !process.env.OAUTH_SECRET) {
 		return [];
@@ -28,7 +51,7 @@ function buildGenericOAuthPlugin() {
 		genericOAuth({
 			config: [
 				{
-					providerId: "oauth",
+					providerId: OAUTH_PROVIDER_ID,
 					clientId: process.env.OAUTH_ID,
 					clientSecret: process.env.OAUTH_SECRET,
 					discoveryUrl: process.env.OAUTH_WELLKNOWN || undefined,
@@ -36,6 +59,12 @@ function buildGenericOAuthPlugin() {
 					tokenUrl: process.env.OAUTH_ACCESS_TOKEN_URL || undefined,
 					userInfoUrl: process.env.OAUTH_USER_INFO || undefined,
 					scopes: (process.env.OAUTH_SCOPE || "openid profile email").split(" "),
+					// PKCE was enforced under next-auth (`checks: ["state","pkce"]`).
+					// better-auth's genericOAuth plugin defaults pkce to false, so we re-enable it.
+					pkce: true,
+					// Pin redirect URI to the legacy path so existing IdP registrations keep working.
+					// See `legacyOAuthRedirectURI` and the rewrite in `next.config.mjs`.
+					redirectURI: legacyOAuthRedirectURI(),
 					mapProfileToUser: (profile) => ({
 						name:
 							profile.name ||
@@ -52,8 +81,21 @@ function buildGenericOAuthPlugin() {
 	];
 }
 
-// ── Before hook: runs before sign-in to enforce cooldown, expiration, TOTP ──
+// ── Before hook: cooldown + 2FA enforcement for credential sign-in only ──
+// Active/expiry checks live in `databaseHooks.session.create.before` so they cover
+// OAuth sign-in too. Password verification is delegated to better-auth (Account.password).
 const beforeHook = createAuthMiddleware(async (ctx) => {
+	// Defense-in-depth: if OAUTH_EXCLUSIVE_LOGIN is on, refuse credential endpoints
+	// even if the UI fails to hide them.
+	if (
+		isOAuthExclusiveLogin() &&
+		(ctx.path === "/sign-in/email" || ctx.path === "/sign-up/email")
+	) {
+		throw new APIError("FORBIDDEN", {
+			message: "Email/password authentication is disabled. Please use OAuth.",
+		});
+	}
+
 	if (ctx.path !== "/sign-in/email") return;
 
 	const email = (ctx.body as Record<string, unknown>)?.email as string;
@@ -61,12 +103,11 @@ const beforeHook = createAuthMiddleware(async (ctx) => {
 
 	const user = await prisma.user.findFirst({
 		where: { email },
-		include: { userGroup: true },
 	});
 
 	if (!user) return; // let better-auth handle "user not found"
 
-	// 1. Cooldown check
+	// 1. Cooldown check (custom, not provided by better-auth)
 	if (user.lastFailedLoginAttempt && user.failedLoginAttempts >= MAX_FAILED_ATTEMPTS) {
 		const timeSinceLastFailed = Date.now() - user.lastFailedLoginAttempt.getTime();
 		if (timeSinceLastFailed < COOLDOWN_PERIOD) {
@@ -76,22 +117,10 @@ const beforeHook = createAuthMiddleware(async (ctx) => {
 		}
 	}
 
-	// 2. Account active/expiry checks
-	if (!user.isActive) {
-		throw new APIError("FORBIDDEN", { message: "account-expired" });
-	}
-	if (user.expiresAt && new Date(user.expiresAt) < new Date()) {
-		throw new APIError("FORBIDDEN", { message: "account-expired" });
-	}
-	if (
-		user.role !== "ADMIN" &&
-		user.userGroup?.expiresAt &&
-		new Date(user.userGroup.expiresAt) < new Date()
-	) {
-		throw new APIError("FORBIDDEN", { message: "account-expired" });
-	}
-
-	// 3. Verify password and track failed attempts
+	// 2. Track failed-password attempts (better-auth checks the password but doesn't
+	// persist failure counters). We compare against User.hash here purely to detect
+	// the failure so we can increment the counter; better-auth re-verifies against
+	// Account.password and is the authoritative check.
 	const password = (ctx.body as Record<string, unknown>)?.password as string;
 	if (password && user.hash) {
 		const isValid = await compare(password, user.hash);
@@ -103,13 +132,15 @@ const beforeHook = createAuthMiddleware(async (ctx) => {
 					lastFailedLoginAttempt: new Date(),
 				},
 			});
-			throw new APIError("UNAUTHORIZED", {
-				message: "Invalid email or password",
-			});
+			// Don't throw — let better-auth produce its standard "invalid credentials"
+			// error so the response shape is identical to a missing-account error.
+			return;
 		}
 	}
 
-	// 4. Ensure credential Account record exists (migration from next-auth)
+	// 3. Ensure credential Account record exists (one-time backfill for users
+	// migrated from next-auth before the Prisma migration ran). The migration
+	// SQL also does this; this is a safety net for race conditions.
 	const existingAccount = await prisma.account.findFirst({
 		where: { userId: user.id, providerId: "credential" },
 	});
@@ -124,7 +155,7 @@ const beforeHook = createAuthMiddleware(async (ctx) => {
 		});
 	}
 
-	// 5. TOTP 2FA check
+	// 4. TOTP 2FA check
 	if (user.twoFactorEnabled) {
 		const totpCode = ctx.headers?.get("x-totp-code");
 
@@ -176,16 +207,45 @@ const beforeHook = createAuthMiddleware(async (ctx) => {
 	}
 });
 
-// ── After hook: runs after sign-in for device tracking, login tracking ──
-const afterHook = createAuthMiddleware(async (ctx) => {
-	if (!ctx.path.startsWith("/sign-in")) return;
+function getIpFromHeaders(headers: Headers | null | undefined): string {
+	if (!headers) return "Unknown";
+	const forwardedFor = headers.get("x-forwarded-for");
+	const ip = forwardedFor ? forwardedFor.split(",")[0].trim() : "Unknown";
+	return ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)?.[1] || ip;
+}
 
-	const newSession = ctx.context?.newSession;
-	if (!newSession) return;
+// Runs for every newly-created session (email sign-in AND OAuth callback). This is
+// where we enforce the active/expiry rules and persist device + login bookkeeping.
+// Exported for unit testing — the production wiring is via `databaseHooks.session.create.before`.
+export async function onSessionCreated(
+	userId: string,
+	// biome-ignore lint/suspicious/noExplicitAny: better-auth's GenericEndpointContext
+	ctx: any | null,
+): Promise<void> {
+	const user = await prisma.user.findUnique({
+		where: { id: userId },
+		include: { userGroup: true },
+	});
+	if (!user) {
+		throw new APIError("UNAUTHORIZED", { message: "user-not-found" });
+	}
 
-	const userId = newSession.user.id;
+	// Active/expiry enforcement (covers credential AND OAuth sign-ins).
+	if (!user.isActive) {
+		throw new APIError("FORBIDDEN", { message: "account-expired" });
+	}
+	if (user.expiresAt && new Date(user.expiresAt) < new Date()) {
+		throw new APIError("FORBIDDEN", { message: "account-expired" });
+	}
+	if (
+		user.role !== "ADMIN" &&
+		user.userGroup?.expiresAt &&
+		new Date(user.userGroup.expiresAt) < new Date()
+	) {
+		throw new APIError("FORBIDDEN", { message: "account-expired" });
+	}
 
-	// 1. Reset failed login attempts + update lastLogin
+	// Reset failed login attempts + update lastLogin
 	await prisma.user.update({
 		where: { id: userId },
 		data: {
@@ -196,29 +256,22 @@ const afterHook = createAuthMiddleware(async (ctx) => {
 		},
 	});
 
-	// 2. Device tracking
-	const userAgent =
-		ctx.headers?.get("x-user-agent") || ctx.headers?.get("user-agent") || "";
+	// Device tracking
+	const headers: Headers | null = ctx?.headers ?? null;
+	const userAgent = headers?.get("x-user-agent") || headers?.get("user-agent") || "";
 	if (!userAgent) return;
 
-	const cookieHeader = ctx.headers?.get("cookie") || "";
+	const cookieHeader = headers?.get("cookie") || "";
 	const cookies = parse(cookieHeader);
 	let deviceId = cookies[DEVICE_SALT_COOKIE_NAME];
+	let isNewCookie = false;
 
 	if (!deviceId) {
 		deviceId = randomBytes(16).toString("hex");
-		// Set cookie via the response context if available
-		try {
-			if (ctx.context?.responseHeaders) {
-				const cookieValue = `${DEVICE_SALT_COOKIE_NAME}=${deviceId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${60 * 60 * 24 * 365}`;
-				ctx.context.responseHeaders.append("set-cookie", cookieValue);
-			}
-		} catch (_e) {
-			// Cookie setting may not be available in all contexts
-		}
+		isNewCookie = true;
 	}
 
-	const ipAddress = getIpFromHeaders(ctx.headers);
+	const ipAddress = getIpFromHeaders(headers);
 	const deviceInfo = {
 		...parseUA(userAgent),
 		userAgent,
@@ -228,7 +281,6 @@ const afterHook = createAuthMiddleware(async (ctx) => {
 		lastActive: new Date(),
 	};
 
-	// Upsert device info
 	const existingDevice = await prisma.userDevice.findUnique({
 		where: { deviceId },
 		select: { ipAddress: true },
@@ -244,14 +296,26 @@ const afterHook = createAuthMiddleware(async (ctx) => {
 		create: deviceInfo,
 	});
 
-	// Send device notification email
-	const user = await prisma.user.findUnique({
+	// Persist the device cookie via better-auth's cookie helper. Setting it AFTER
+	// the upsert ensures a row exists before the cookie is observed by /api/auth/me.
+	if (isNewCookie && typeof ctx?.setCookie === "function") {
+		ctx.setCookie(DEVICE_SALT_COOKIE_NAME, deviceId, {
+			httpOnly: true,
+			sameSite: "lax",
+			path: "/",
+			maxAge: 60 * 60 * 24 * 365, // 1 year
+		});
+	}
+
+	// New-device / IP-change email notification (only after the user's first login;
+	// `firstTime=true` is reset above before this query, so re-read).
+	const refreshed = await prisma.user.findUnique({
 		where: { id: userId },
-		select: { email: true, id: true, firstTime: true },
+		select: { email: true, id: true },
 	});
 
 	try {
-		if (user && !user.firstTime) {
+		if (refreshed && !user.firstTime) {
 			const templateKey = !existingDevice
 				? MailTemplateKey.NewDeviceNotification
 				: existingDevice.ipAddress !== ipAddress
@@ -260,10 +324,10 @@ const afterHook = createAuthMiddleware(async (ctx) => {
 
 			if (templateKey) {
 				await sendMailWithTemplate(templateKey, {
-					to: user.email,
-					userId: user.id,
+					to: refreshed.email,
+					userId: refreshed.id,
 					templateData: {
-						toEmail: user.email,
+						toEmail: refreshed.email,
 						accessTime: new Date().toISOString(),
 						ipAddress,
 						browserInfo: userAgent,
@@ -277,13 +341,59 @@ const afterHook = createAuthMiddleware(async (ctx) => {
 			"Failed to send email notification for new device, check your mail settings.",
 		);
 	}
-});
+}
 
-function getIpFromHeaders(headers: Headers | null): string {
-	if (!headers) return "Unknown";
-	const forwardedFor = headers.get("x-forwarded-for");
-	const ip = forwardedFor ? forwardedFor.split(",")[0].trim() : "Unknown";
-	return ip.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/)?.[1] || ip;
+// User-creation hook. Enforces OAUTH_ALLOW_NEW_USERS / global registration toggle
+// when the create is triggered by the OAuth callback flow, and stamps the standard
+// ztnet defaults onto the new row (role, group, firstTime, etc.).
+// Exported for unit testing.
+export async function onUserCreateBefore(
+	user: Record<string, unknown>,
+	// biome-ignore lint/suspicious/noExplicitAny: better-auth's GenericEndpointContext
+	ctx: any | null,
+): Promise<{ data: Record<string, unknown> }> {
+	const path: string | undefined = ctx?.path;
+	const isOAuthFlow =
+		typeof path === "string" &&
+		(path.startsWith("/oauth2/callback/") || path === "/sign-in/oauth2");
+
+	if (isOAuthFlow) {
+		// Honour OAUTH_ALLOW_NEW_USERS — block OAuth account creation when off.
+		if (!isOAuthAllowNewUsers()) {
+			throw new APIError("FORBIDDEN", {
+				message: "registration_disabled",
+			});
+		}
+
+		// Outside of exclusive-OAuth mode, also respect the global registration toggle.
+		if (!isOAuthExclusiveLogin()) {
+			const settings = await prisma.globalOptions.findFirst({
+				where: { id: 1 },
+				select: { enableRegistration: true },
+			});
+			if (!settings?.enableRegistration) {
+				throw new APIError("FORBIDDEN", {
+					message: "registration_disabled",
+				});
+			}
+		}
+	}
+
+	const userCount = await prisma.user.count();
+	const defaultUserGroup = await prisma.userGroup.findFirst({
+		where: { isDefault: true },
+	});
+
+	return {
+		data: {
+			...user,
+			role: userCount === 0 ? "ADMIN" : "USER",
+			lastLogin: new Date(),
+			firstTime: true,
+			isActive: true,
+			userGroupId: defaultUserGroup?.id ?? undefined,
+		},
+	};
 }
 
 export const auth = betterAuth({
@@ -299,8 +409,13 @@ export const auth = betterAuth({
 		expiresIn:
 			Number.parseInt(process.env.NEXTAUTH_SESSION_MAX_AGE, 10) || 30 * 24 * 60 * 60,
 		cookieCache: {
-			enabled: true,
-			maxAge: 5 * 60, // 5 minute cache
+			// Disabled: better-auth's cookie cache returns the cached user object
+			// (including `isActive`, `requestChangePassword`, `role`) without hitting
+			// the DB until `maxAge` elapses. For ztnet we explicitly need an admin
+			// disabling a user (or a cron job expiring an account) to take effect on
+			// the user's NEXT request, not minutes later. The DB hit per request is
+			// cheap and worth the consistency.
+			enabled: false,
 		},
 	},
 
@@ -344,7 +459,7 @@ export const auth = betterAuth({
 			enabled:
 				(process.env.OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING ?? "true").toLowerCase() !==
 				"false",
-			trustedProviders: ["oauth"],
+			trustedProviders: [OAUTH_PROVIDER_ID],
 		},
 	},
 
@@ -352,28 +467,21 @@ export const auth = betterAuth({
 
 	hooks: {
 		before: beforeHook,
-		after: afterHook,
 	},
 
 	databaseHooks: {
 		user: {
 			create: {
-				before: async (user) => {
-					const userCount = await prisma.user.count();
-					const defaultUserGroup = await prisma.userGroup.findFirst({
-						where: { isDefault: true },
-					});
-
-					return {
-						data: {
-							...user,
-							role: userCount === 0 ? "ADMIN" : "USER",
-							lastLogin: new Date(),
-							firstTime: true,
-							isActive: true,
-							userGroupId: defaultUserGroup?.id ?? undefined,
-						},
-					};
+				before: onUserCreateBefore,
+			},
+		},
+		session: {
+			create: {
+				before: async (session, ctx) => {
+					// Fires for every newly-created session (credential + OAuth).
+					// Throws abort the session creation so the user is never logged in
+					// when their account is disabled or expired.
+					await onSessionCreated(session.userId as string, ctx);
 				},
 			},
 		},

--- a/src/server/api/__tests__/services/authHooks.test.ts
+++ b/src/server/api/__tests__/services/authHooks.test.ts
@@ -1,0 +1,340 @@
+/**
+ * Tests for the better-auth `databaseHooks` we wire up in `src/lib/auth.ts`.
+ *
+ * These hooks are the migration's main correctness boundary:
+ *   - `onUserCreateBefore` enforces OAUTH_ALLOW_NEW_USERS and the global
+ *     `enableRegistration` toggle for OAuth-triggered user creation. Pre-migration
+ *     this lived in next-auth's signin callback; the new hook needs to behave
+ *     identically.
+ *   - `onSessionCreated` enforces `isActive`, per-user expiry, and per-userGroup
+ *     expiry for EVERY sign-in (credential AND OAuth). Pre-migration this was on
+ *     the credential authorize() path only and was missing from OAuth — those
+ *     blocked-user-can-still-sign-in-via-OAuth cases are what these tests pin down.
+ */
+
+import { onSessionCreated, onUserCreateBefore } from "~/lib/auth";
+import { prisma } from "~/server/db";
+
+jest.mock("~/server/db", () => ({
+	prisma: {
+		user: {
+			findUnique: jest.fn(),
+			update: jest.fn(),
+			count: jest.fn(),
+		},
+		userGroup: {
+			findFirst: jest.fn(),
+		},
+		userDevice: {
+			findUnique: jest.fn(),
+			upsert: jest.fn(),
+		},
+		globalOptions: {
+			findFirst: jest.fn(),
+		},
+	},
+}));
+
+jest.mock("~/utils/mail", () => ({
+	sendMailWithTemplate: jest.fn(),
+}));
+
+const ENV_BACKUP = { ...process.env };
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	process.env = { ...ENV_BACKUP };
+	process.env.NEXTAUTH_URL = "https://ztnet.example";
+});
+
+afterAll(() => {
+	process.env = ENV_BACKUP;
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// onUserCreateBefore
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("onUserCreateBefore", () => {
+	const baseUser = { id: "u1", email: "new@example.com", name: "New User" };
+
+	it("stamps role=ADMIN on the very first user (userCount=0)", async () => {
+		(prisma.user.count as jest.Mock).mockResolvedValue(0);
+		(prisma.userGroup.findFirst as jest.Mock).mockResolvedValue(null);
+
+		const result = await onUserCreateBefore(baseUser, { path: "/sign-up/email" });
+		expect(result.data.role).toBe("ADMIN");
+		expect(result.data.firstTime).toBe(true);
+		expect(result.data.isActive).toBe(true);
+	});
+
+	it("stamps role=USER for subsequent users", async () => {
+		(prisma.user.count as jest.Mock).mockResolvedValue(7);
+		(prisma.userGroup.findFirst as jest.Mock).mockResolvedValue(null);
+
+		const result = await onUserCreateBefore(baseUser, { path: "/sign-up/email" });
+		expect(result.data.role).toBe("USER");
+	});
+
+	it("attaches the default user group when one exists", async () => {
+		(prisma.user.count as jest.Mock).mockResolvedValue(2);
+		(prisma.userGroup.findFirst as jest.Mock).mockResolvedValue({ id: 42 });
+
+		const result = await onUserCreateBefore(baseUser, { path: "/sign-up/email" });
+		expect(result.data.userGroupId).toBe(42);
+	});
+
+	describe("OAuth flow gating", () => {
+		const oauthCtx = { path: "/oauth2/callback/oauth" };
+
+		it("blocks new OAuth users when OAUTH_ALLOW_NEW_USERS=false", async () => {
+			process.env.OAUTH_ALLOW_NEW_USERS = "false";
+			await expect(onUserCreateBefore(baseUser, oauthCtx)).rejects.toThrow(
+				/registration_disabled/,
+			);
+			expect(prisma.user.count).not.toHaveBeenCalled();
+		});
+
+		it("blocks new OAuth users when global enableRegistration is off", async () => {
+			process.env.OAUTH_ALLOW_NEW_USERS = "true";
+			process.env.OAUTH_EXCLUSIVE_LOGIN = "false";
+			(prisma.globalOptions.findFirst as jest.Mock).mockResolvedValue({
+				enableRegistration: false,
+			});
+
+			await expect(onUserCreateBefore(baseUser, oauthCtx)).rejects.toThrow(
+				/registration_disabled/,
+			);
+		});
+
+		it("allows OAuth users when registration is on", async () => {
+			process.env.OAUTH_ALLOW_NEW_USERS = "true";
+			process.env.OAUTH_EXCLUSIVE_LOGIN = "false";
+			(prisma.globalOptions.findFirst as jest.Mock).mockResolvedValue({
+				enableRegistration: true,
+			});
+			(prisma.user.count as jest.Mock).mockResolvedValue(3);
+			(prisma.userGroup.findFirst as jest.Mock).mockResolvedValue(null);
+
+			const result = await onUserCreateBefore(baseUser, oauthCtx);
+			expect(result.data.role).toBe("USER");
+		});
+
+		it("ignores enableRegistration when OAUTH_EXCLUSIVE_LOGIN=true (OAuth bypasses the global toggle by design)", async () => {
+			process.env.OAUTH_ALLOW_NEW_USERS = "true";
+			process.env.OAUTH_EXCLUSIVE_LOGIN = "true";
+			// globalOptions intentionally not mocked — must not be queried.
+			(prisma.user.count as jest.Mock).mockResolvedValue(3);
+			(prisma.userGroup.findFirst as jest.Mock).mockResolvedValue(null);
+
+			await expect(onUserCreateBefore(baseUser, oauthCtx)).resolves.toMatchObject({
+				data: expect.any(Object),
+			});
+			expect(prisma.globalOptions.findFirst).not.toHaveBeenCalled();
+		});
+
+		it("does NOT enforce OAuth gating on email sign-up paths", async () => {
+			// The tRPC `register` procedure handles email registration with its own
+			// enableRegistration guard; better-auth's user-create hook should not
+			// double-gate it from the credential flow.
+			process.env.OAUTH_ALLOW_NEW_USERS = "false";
+			(prisma.user.count as jest.Mock).mockResolvedValue(3);
+			(prisma.userGroup.findFirst as jest.Mock).mockResolvedValue(null);
+
+			await expect(
+				onUserCreateBefore(baseUser, { path: "/sign-up/email" }),
+			).resolves.toBeTruthy();
+		});
+	});
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// onSessionCreated
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("onSessionCreated", () => {
+	const ACTIVE_USER = {
+		id: "u1",
+		email: "u1@example.com",
+		isActive: true,
+		expiresAt: null,
+		role: "USER",
+		firstTime: false,
+		userGroup: null,
+	};
+
+	function makeCtx(
+		overrides: Partial<{
+			userAgent: string;
+			cookieDeviceId: string;
+			setCookie: jest.Mock;
+		}> = {},
+	) {
+		const headers = new Headers();
+		if (overrides.userAgent !== undefined) {
+			headers.set("user-agent", overrides.userAgent);
+		} else {
+			headers.set("user-agent", "Mozilla/5.0 Chrome Test");
+		}
+		headers.set("x-forwarded-for", "203.0.113.4");
+		if (overrides.cookieDeviceId) {
+			headers.set("cookie", `next-auth.did-token=${overrides.cookieDeviceId}`);
+		}
+		return {
+			headers,
+			setCookie: overrides.setCookie ?? jest.fn(),
+			path: "/sign-in/email",
+		};
+	}
+
+	it("rejects when the user is missing", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue(null);
+		await expect(onSessionCreated("missing", makeCtx())).rejects.toThrow(
+			/user-not-found/,
+		);
+	});
+
+	it("rejects credential sign-in when isActive=false", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue({
+			...ACTIVE_USER,
+			isActive: false,
+		});
+		await expect(onSessionCreated("u1", makeCtx())).rejects.toThrow(/account-expired/);
+		expect(prisma.user.update).not.toHaveBeenCalled(); // bookkeeping never runs
+	});
+
+	it("rejects OAuth sign-in when isActive=false (the regression #4)", async () => {
+		// Pre-fix, the after-hook only fired on `/sign-in/*` paths so the OAuth
+		// callback (`/oauth2/callback/:providerId`) skipped this check entirely
+		// and disabled users could log in with OAuth. This test pins the fix down.
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue({
+			...ACTIVE_USER,
+			isActive: false,
+		});
+		const ctx = makeCtx();
+		ctx.path = "/oauth2/callback/oauth";
+		await expect(onSessionCreated("u1", ctx)).rejects.toThrow(/account-expired/);
+	});
+
+	it("rejects when the user is past expiresAt", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue({
+			...ACTIVE_USER,
+			expiresAt: new Date(Date.now() - 1000),
+		});
+		await expect(onSessionCreated("u1", makeCtx())).rejects.toThrow(/account-expired/);
+	});
+
+	it("rejects when the user's group is past expiresAt (non-admin)", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue({
+			...ACTIVE_USER,
+			userGroup: { expiresAt: new Date(Date.now() - 1000) },
+		});
+		await expect(onSessionCreated("u1", makeCtx())).rejects.toThrow(/account-expired/);
+	});
+
+	it("does NOT reject ADMIN even when their userGroup is expired", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue({
+			...ACTIVE_USER,
+			role: "ADMIN",
+			userGroup: { expiresAt: new Date(Date.now() - 1000) },
+		});
+		(prisma.user.update as jest.Mock).mockResolvedValue({});
+		(prisma.userDevice.findUnique as jest.Mock).mockResolvedValue(null);
+		(prisma.userDevice.upsert as jest.Mock).mockResolvedValue({});
+
+		await expect(onSessionCreated("u1", makeCtx())).resolves.toBeUndefined();
+		expect(prisma.user.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { id: "u1" },
+				data: expect.objectContaining({ failedLoginAttempts: 0 }),
+			}),
+		);
+	});
+
+	it("resets failedLoginAttempts and stamps lastLogin on success", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue(ACTIVE_USER);
+		(prisma.user.update as jest.Mock).mockResolvedValue({});
+		(prisma.userDevice.findUnique as jest.Mock).mockResolvedValue(null);
+		(prisma.userDevice.upsert as jest.Mock).mockResolvedValue({});
+
+		await onSessionCreated("u1", makeCtx());
+
+		const updateCall = (prisma.user.update as jest.Mock).mock.calls[0][0];
+		expect(updateCall.where).toEqual({ id: "u1" });
+		expect(updateCall.data.failedLoginAttempts).toBe(0);
+		expect(updateCall.data.lastFailedLoginAttempt).toBeNull();
+		expect(updateCall.data.firstTime).toBe(false);
+		expect(updateCall.data.lastLogin).toBeInstanceOf(Date);
+	});
+
+	it("upserts a UserDevice using the cookie device id and stamps the IP", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue(ACTIVE_USER);
+		(prisma.user.update as jest.Mock).mockResolvedValue({});
+		(prisma.userDevice.findUnique as jest.Mock).mockResolvedValue(null);
+		(prisma.userDevice.upsert as jest.Mock).mockResolvedValue({});
+
+		await onSessionCreated("u1", makeCtx({ cookieDeviceId: "abc123" }));
+
+		expect(prisma.userDevice.upsert).toHaveBeenCalledWith(
+			expect.objectContaining({
+				where: { deviceId: "abc123" },
+				create: expect.objectContaining({
+					deviceId: "abc123",
+					userId: "u1",
+					ipAddress: "203.0.113.4",
+				}),
+			}),
+		);
+	});
+
+	it("generates a new device id when no cookie is present and writes it via ctx.setCookie", async () => {
+		// This is the fix for #6 — pre-fix, the device cookie was written via a
+		// non-public `ctx.context.responseHeaders` API and frequently lost. We now
+		// use better-auth's documented `ctx.setCookie(name, value, opts)`.
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue(ACTIVE_USER);
+		(prisma.user.update as jest.Mock).mockResolvedValue({});
+		(prisma.userDevice.findUnique as jest.Mock).mockResolvedValue(null);
+		(prisma.userDevice.upsert as jest.Mock).mockResolvedValue({});
+
+		const setCookie = jest.fn();
+		await onSessionCreated("u1", makeCtx({ setCookie }));
+
+		expect(setCookie).toHaveBeenCalledTimes(1);
+		const [cookieName, cookieValue, opts] = setCookie.mock.calls[0];
+		expect(cookieName).toBe("next-auth.did-token");
+		expect(typeof cookieValue).toBe("string");
+		expect(cookieValue.length).toBeGreaterThan(8);
+		expect(opts).toEqual(
+			expect.objectContaining({
+				httpOnly: true,
+				sameSite: "lax",
+				path: "/",
+			}),
+		);
+	});
+
+	it("does NOT call ctx.setCookie when an existing device cookie is present", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue(ACTIVE_USER);
+		(prisma.user.update as jest.Mock).mockResolvedValue({});
+		(prisma.userDevice.findUnique as jest.Mock).mockResolvedValue({
+			ipAddress: "203.0.113.4",
+		});
+		(prisma.userDevice.upsert as jest.Mock).mockResolvedValue({});
+
+		const setCookie = jest.fn();
+		await onSessionCreated(
+			"u1",
+			makeCtx({ setCookie, cookieDeviceId: "existing-device" }),
+		);
+
+		expect(setCookie).not.toHaveBeenCalled();
+	});
+
+	it("skips device tracking entirely when no user-agent is present (e.g. some API consumers)", async () => {
+		(prisma.user.findUnique as jest.Mock).mockResolvedValue(ACTIVE_USER);
+		(prisma.user.update as jest.Mock).mockResolvedValue({});
+
+		await onSessionCreated("u1", makeCtx({ userAgent: "" }));
+		expect(prisma.userDevice.upsert).not.toHaveBeenCalled();
+	});
+});

--- a/src/server/api/__tests__/services/beforeHook.test.ts
+++ b/src/server/api/__tests__/services/beforeHook.test.ts
@@ -1,0 +1,358 @@
+/**
+ * Tests for the credential sign-in pre-flight middleware (`runBeforeAuthHook`).
+ *
+ * This middleware fires before better-auth verifies the password against
+ * Account.password. It owns:
+ *   1. OAUTH_EXCLUSIVE_LOGIN defense-in-depth (refuse /sign-in/email + /sign-up/email).
+ *   2. Per-account cooldown after MAX_FAILED_ATTEMPTS bad logins.
+ *   3. Failed-password attempt counter increment (without throwing — better-auth
+ *      produces the user-facing 401, we just bookkeep).
+ *   4. One-time backfill of the credential `Account` row for users who pre-date
+ *      the next-auth → better-auth migration. Without this, their first login
+ *      after upgrade would fail because better-auth reads from `Account.password`.
+ *   5. TOTP enforcement when `User.twoFactorEnabled = true`.
+ *
+ * Bypassing any of these is a security regression, so each path has an explicit test.
+ */
+import { runBeforeAuthHook } from "~/lib/auth";
+import { prisma } from "~/server/db";
+
+jest.mock("~/server/db", () => ({
+	prisma: {
+		user: {
+			findFirst: jest.fn(),
+			update: jest.fn(),
+		},
+		account: {
+			findFirst: jest.fn(),
+			create: jest.fn(),
+		},
+	},
+}));
+
+jest.mock("bcryptjs", () => ({
+	compare: jest.fn(),
+	hash: jest.fn(),
+}));
+
+jest.mock("otplib", () => ({
+	authenticator: {
+		check: jest.fn(),
+	},
+}));
+
+jest.mock("~/utils/encryption", () => ({
+	decrypt: jest.fn(),
+	generateInstanceSecret: jest.fn(() => "secret"),
+	TOTP_MFA_TOKEN_SECRET: "TOTP_MFA_TOKEN_SECRET",
+}));
+
+import { compare } from "bcryptjs";
+import { authenticator } from "otplib";
+import { decrypt } from "~/utils/encryption";
+
+const ENV_KEYS = ["OAUTH_EXCLUSIVE_LOGIN", "NEXTAUTH_SECRET"] as const;
+const ENV_BACKUP = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+beforeEach(() => {
+	jest.clearAllMocks();
+	// biome-ignore lint/performance/noDelete: must actually unset the env key
+	delete process.env.OAUTH_EXCLUSIVE_LOGIN;
+	process.env.NEXTAUTH_SECRET = "test_secret";
+});
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(ENV_BACKUP)) {
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+});
+
+function makeCtx(overrides: {
+	path?: string;
+	email?: string;
+	password?: string;
+	totpCode?: string | null;
+}) {
+	const headers = new Headers();
+	if (overrides.totpCode !== undefined && overrides.totpCode !== null) {
+		headers.set("x-totp-code", overrides.totpCode);
+	}
+	const body: Record<string, unknown> = {};
+	if (overrides.email !== undefined) body.email = overrides.email;
+	if (overrides.password !== undefined) body.password = overrides.password;
+	return {
+		path: overrides.path ?? "/sign-in/email",
+		body,
+		headers,
+	};
+}
+
+describe("OAUTH_EXCLUSIVE_LOGIN defense-in-depth", () => {
+	it("rejects POST /sign-in/email when exclusive OAuth is on", async () => {
+		process.env.OAUTH_EXCLUSIVE_LOGIN = "true";
+		await expect(runBeforeAuthHook(makeCtx({ path: "/sign-in/email" }))).rejects.toThrow(
+			/Email\/password authentication is disabled/i,
+		);
+		expect(prisma.user.findFirst).not.toHaveBeenCalled();
+	});
+
+	it("rejects POST /sign-up/email when exclusive OAuth is on", async () => {
+		process.env.OAUTH_EXCLUSIVE_LOGIN = "true";
+		await expect(runBeforeAuthHook(makeCtx({ path: "/sign-up/email" }))).rejects.toThrow(
+			/Email\/password authentication is disabled/i,
+		);
+	});
+
+	it("ignores other paths even when exclusive OAuth is on", async () => {
+		process.env.OAUTH_EXCLUSIVE_LOGIN = "true";
+		await expect(
+			runBeforeAuthHook(makeCtx({ path: "/sign-out" })),
+		).resolves.toBeUndefined();
+	});
+
+	it("does not block /sign-in/email when exclusive OAuth is off", async () => {
+		process.env.OAUTH_EXCLUSIVE_LOGIN = "false";
+		// no email in body → early return (line 121 of auth.ts)
+		await expect(
+			runBeforeAuthHook(makeCtx({ path: "/sign-in/email" })),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("Cooldown after MAX_FAILED_ATTEMPTS", () => {
+	it("throws TOO_MANY_REQUESTS when failedLoginAttempts >= 5 within the cooldown window", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			id: "u1",
+			email: "u@example.com",
+			hash: "$2a$10$x",
+			failedLoginAttempts: 5,
+			lastFailedLoginAttempt: new Date(Date.now() - 10_000), // 10s ago
+			twoFactorEnabled: false,
+		});
+
+		await expect(
+			runBeforeAuthHook(makeCtx({ email: "u@example.com", password: "x" })),
+		).rejects.toThrow(/Too many failed attempts/i);
+	});
+
+	it("does NOT throw once the 1-minute cooldown has elapsed", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			id: "u1",
+			email: "u@example.com",
+			hash: "$2a$10$x",
+			failedLoginAttempts: 5,
+			lastFailedLoginAttempt: new Date(Date.now() - 90_000), // 90s ago > 60s
+			twoFactorEnabled: false,
+		});
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({ id: "acc" });
+
+		await expect(
+			runBeforeAuthHook(makeCtx({ email: "u@example.com", password: "x" })),
+		).resolves.toBeUndefined();
+	});
+});
+
+describe("failed-password bookkeeping", () => {
+	it("increments failedLoginAttempts on bad password but does NOT throw (better-auth owns the 401)", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			id: "u1",
+			email: "u@example.com",
+			hash: "$2a$10$x",
+			failedLoginAttempts: 0,
+			lastFailedLoginAttempt: null,
+			twoFactorEnabled: false,
+		});
+		(compare as jest.Mock).mockResolvedValue(false);
+
+		await expect(
+			runBeforeAuthHook(makeCtx({ email: "u@example.com", password: "wrong" })),
+		).resolves.toBeUndefined();
+
+		expect(prisma.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: {
+				failedLoginAttempts: { increment: 1 },
+				lastFailedLoginAttempt: expect.any(Date),
+			},
+		});
+	});
+
+	it("does nothing when the user is unknown (better-auth handles the 401)", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue(null);
+		await expect(
+			runBeforeAuthHook(makeCtx({ email: "ghost@example.com", password: "x" })),
+		).resolves.toBeUndefined();
+		expect(prisma.user.update).not.toHaveBeenCalled();
+	});
+});
+
+describe("credential Account backfill", () => {
+	it("creates the credential Account row on first login if it's missing (next-auth migration safety net)", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			id: "u1",
+			email: "u@example.com",
+			hash: "$2a$10$existing",
+			failedLoginAttempts: 0,
+			lastFailedLoginAttempt: null,
+			twoFactorEnabled: false,
+		});
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue(null);
+
+		await runBeforeAuthHook(makeCtx({ email: "u@example.com", password: "right" }));
+
+		expect(prisma.account.create).toHaveBeenCalledWith({
+			data: {
+				userId: "u1",
+				accountId: "u1",
+				providerId: "credential",
+				password: "$2a$10$existing",
+			},
+		});
+	});
+
+	it("does NOT recreate the Account if it already exists", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			id: "u1",
+			email: "u@example.com",
+			hash: "$2a$10$existing",
+			failedLoginAttempts: 0,
+			lastFailedLoginAttempt: null,
+			twoFactorEnabled: false,
+		});
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({
+			id: "acc",
+			providerId: "credential",
+		});
+
+		await runBeforeAuthHook(makeCtx({ email: "u@example.com", password: "right" }));
+
+		expect(prisma.account.create).not.toHaveBeenCalled();
+	});
+
+	it("skips backfill for OAuth-only users (no User.hash)", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			id: "u1",
+			email: "u@example.com",
+			hash: null,
+			failedLoginAttempts: 0,
+			lastFailedLoginAttempt: null,
+			twoFactorEnabled: false,
+		});
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue(null);
+
+		await runBeforeAuthHook(makeCtx({ email: "u@example.com", password: "any" }));
+		expect(prisma.account.create).not.toHaveBeenCalled();
+	});
+});
+
+describe("TOTP 2FA enforcement", () => {
+	const userWith2FA = {
+		id: "u1",
+		email: "u@example.com",
+		hash: "$2a$10$existing",
+		failedLoginAttempts: 0,
+		lastFailedLoginAttempt: null,
+		twoFactorEnabled: true,
+		twoFactorSecret: "encrypted-secret",
+	};
+
+	it("throws second-factor-required when the user has 2FA on and no x-totp-code header", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue(userWith2FA);
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({ id: "acc" });
+
+		await expect(
+			runBeforeAuthHook(
+				makeCtx({ email: "u@example.com", password: "right", totpCode: null }),
+			),
+		).rejects.toThrow(/second-factor-required/);
+	});
+
+	it("rejects when the TOTP code doesn't validate", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue(userWith2FA);
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({ id: "acc" });
+		(decrypt as jest.Mock).mockReturnValue("12345678901234567890123456789012"); // 32 chars
+		(authenticator.check as jest.Mock).mockReturnValue(false);
+
+		await expect(
+			runBeforeAuthHook(
+				makeCtx({
+					email: "u@example.com",
+					password: "right",
+					totpCode: "000000",
+				}),
+			),
+		).rejects.toThrow(/incorrect-two-factor-code/);
+
+		// failed-attempts increments on bad TOTP too
+		expect(prisma.user.update).toHaveBeenCalledWith({
+			where: { id: "u1" },
+			data: {
+				failedLoginAttempts: { increment: 1 },
+				lastFailedLoginAttempt: expect.any(Date),
+			},
+		});
+	});
+
+	it("accepts a valid TOTP code and allows the request to proceed", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue(userWith2FA);
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({ id: "acc" });
+		(decrypt as jest.Mock).mockReturnValue("12345678901234567890123456789012");
+		(authenticator.check as jest.Mock).mockReturnValue(true);
+
+		await expect(
+			runBeforeAuthHook(
+				makeCtx({
+					email: "u@example.com",
+					password: "right",
+					totpCode: "123456",
+				}),
+			),
+		).resolves.toBeUndefined();
+	});
+
+	it("returns 500 (INTERNAL_SERVER_ERROR) when 2FA is on but no secret stored — should never happen but must not log the user in", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue({
+			...userWith2FA,
+			twoFactorSecret: null,
+		});
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({ id: "acc" });
+
+		await expect(
+			runBeforeAuthHook(
+				makeCtx({
+					email: "u@example.com",
+					password: "right",
+					totpCode: "123456",
+				}),
+			),
+		).rejects.toThrow(/Internal server error/);
+	});
+
+	it("returns 500 when the encrypted TOTP secret has the wrong length (encryption-key drift)", async () => {
+		(prisma.user.findFirst as jest.Mock).mockResolvedValue(userWith2FA);
+		(compare as jest.Mock).mockResolvedValue(true);
+		(prisma.account.findFirst as jest.Mock).mockResolvedValue({ id: "acc" });
+		(decrypt as jest.Mock).mockReturnValue("too-short");
+
+		await expect(
+			runBeforeAuthHook(
+				makeCtx({
+					email: "u@example.com",
+					password: "right",
+					totpCode: "123456",
+				}),
+			),
+		).rejects.toThrow(/Internal server error/);
+	});
+});

--- a/src/server/api/__tests__/services/credentialAccountService.test.ts
+++ b/src/server/api/__tests__/services/credentialAccountService.test.ts
@@ -1,0 +1,49 @@
+import { upsertCredentialAccount } from "~/server/api/services/credentialAccountService";
+import { prisma } from "~/server/db";
+
+jest.mock("~/server/db", () => ({
+	prisma: {
+		account: {
+			upsert: jest.fn(),
+		},
+	},
+}));
+
+describe("upsertCredentialAccount", () => {
+	beforeEach(() => {
+		(prisma.account.upsert as jest.Mock).mockReset();
+	});
+
+	it("upserts the credential Account row keyed by (providerId, accountId)", async () => {
+		// better-auth reads passwords from `Account` where `providerId='credential'`
+		// and `accountId=<userId>`. The upsert MUST use that compound unique key,
+		// otherwise we'd create duplicate rows on every password change.
+		(prisma.account.upsert as jest.Mock).mockResolvedValue({});
+
+		await upsertCredentialAccount("user_123", "$2a$10$bcrypthash");
+
+		expect(prisma.account.upsert).toHaveBeenCalledTimes(1);
+		expect(prisma.account.upsert).toHaveBeenCalledWith({
+			where: {
+				providerId_accountId: {
+					providerId: "credential",
+					accountId: "user_123",
+				},
+			},
+			create: {
+				userId: "user_123",
+				accountId: "user_123",
+				providerId: "credential",
+				password: "$2a$10$bcrypthash",
+			},
+			update: {
+				password: "$2a$10$bcrypthash",
+			},
+		});
+	});
+
+	it("propagates DB errors instead of swallowing them", async () => {
+		(prisma.account.upsert as jest.Mock).mockRejectedValue(new Error("db down"));
+		await expect(upsertCredentialAccount("user_123", "hash")).rejects.toThrow("db down");
+	});
+});

--- a/src/server/api/__tests__/services/oauthConfig.test.ts
+++ b/src/server/api/__tests__/services/oauthConfig.test.ts
@@ -1,15 +1,16 @@
 /**
- * Pins down the OAuth config-shape contract for the genericOAuth plugin.
+ * Pins down the OAuth config-shape contract.
  *
  * These are configuration assertions, not behaviour tests — they exist to catch
  * silent regressions on the things that broke in production during the
  * next-auth → better-auth migration:
  *
  *   - PKCE was off by default in `genericOAuth` (next-auth had it on); we re-enable it.
- *   - The default callback URL changed from `/api/auth/callback/oauth` (next-auth)
- *     to `/api/auth/oauth2/callback/oauth` (better-auth). Pinning `redirectURI`
- *     to the legacy path keeps existing IdP registrations working — see also the
- *     Next.js rewrite in `next.config.mjs`.
+ *   - We use `signIn.social` (not `signIn.oauth2`) so the IdP callback URL stays
+ *     at the legacy `/api/auth/callback/oauth` path documented at
+ *     https://ztnet.network/authentication/oauth. The genericOAuth plugin's
+ *     init() injects the provider into `socialProviders` so it still drives
+ *     the flow (PKCE, mapProfileToUser, discoveryUrl, ...).
  *
  * If any of these constants drifts, every self-hosted ztnet install will fail
  * to log in via OAuth.
@@ -20,7 +21,6 @@ import {
 	auth,
 	isOAuthAllowNewUsers,
 	isOAuthExclusiveLogin,
-	legacyOAuthRedirectURI,
 } from "~/lib/auth";
 
 describe("OAuth configuration shape", () => {
@@ -32,28 +32,6 @@ describe("OAuth configuration shape", () => {
 
 	afterAll(() => {
 		process.env = ENV_BACKUP;
-	});
-
-	describe("legacyOAuthRedirectURI()", () => {
-		it("returns the legacy /api/auth/callback/<providerId> path", () => {
-			process.env.NEXTAUTH_URL = "https://ztnet.example.com";
-			expect(legacyOAuthRedirectURI()).toBe(
-				"https://ztnet.example.com/api/auth/callback/oauth",
-			);
-		});
-
-		it("strips a trailing slash from NEXTAUTH_URL so the path is well-formed", () => {
-			process.env.NEXTAUTH_URL = "https://ztnet.example.com/";
-			expect(legacyOAuthRedirectURI()).toBe(
-				"https://ztnet.example.com/api/auth/callback/oauth",
-			);
-		});
-
-		it("returns undefined when NEXTAUTH_URL is missing (test/build env)", () => {
-			// biome-ignore lint/performance/noDelete: must actually unset the env key
-			delete process.env.NEXTAUTH_URL;
-			expect(legacyOAuthRedirectURI()).toBeUndefined();
-		});
 	});
 
 	describe("OAUTH_PROVIDER_ID", () => {

--- a/src/server/api/__tests__/services/oauthConfig.test.ts
+++ b/src/server/api/__tests__/services/oauthConfig.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Pins down the OAuth config-shape contract for the genericOAuth plugin.
+ *
+ * These are configuration assertions, not behaviour tests — they exist to catch
+ * silent regressions on the things that broke in production during the
+ * next-auth → better-auth migration:
+ *
+ *   - PKCE was off by default in `genericOAuth` (next-auth had it on); we re-enable it.
+ *   - The default callback URL changed from `/api/auth/callback/oauth` (next-auth)
+ *     to `/api/auth/oauth2/callback/oauth` (better-auth). Pinning `redirectURI`
+ *     to the legacy path keeps existing IdP registrations working — see also the
+ *     Next.js rewrite in `next.config.mjs`.
+ *
+ * If any of these constants drifts, every self-hosted ztnet install will fail
+ * to log in via OAuth.
+ */
+
+import {
+	OAUTH_PROVIDER_ID,
+	auth,
+	isOAuthAllowNewUsers,
+	isOAuthExclusiveLogin,
+	legacyOAuthRedirectURI,
+} from "~/lib/auth";
+
+describe("OAuth configuration shape", () => {
+	const ENV_BACKUP = { ...process.env };
+
+	beforeEach(() => {
+		process.env = { ...ENV_BACKUP };
+	});
+
+	afterAll(() => {
+		process.env = ENV_BACKUP;
+	});
+
+	describe("legacyOAuthRedirectURI()", () => {
+		it("returns the legacy /api/auth/callback/<providerId> path", () => {
+			process.env.NEXTAUTH_URL = "https://ztnet.example.com";
+			expect(legacyOAuthRedirectURI()).toBe(
+				"https://ztnet.example.com/api/auth/callback/oauth",
+			);
+		});
+
+		it("strips a trailing slash from NEXTAUTH_URL so the path is well-formed", () => {
+			process.env.NEXTAUTH_URL = "https://ztnet.example.com/";
+			expect(legacyOAuthRedirectURI()).toBe(
+				"https://ztnet.example.com/api/auth/callback/oauth",
+			);
+		});
+
+		it("returns undefined when NEXTAUTH_URL is missing (test/build env)", () => {
+			// biome-ignore lint/performance/noDelete: must actually unset the env key
+			delete process.env.NEXTAUTH_URL;
+			expect(legacyOAuthRedirectURI()).toBeUndefined();
+		});
+	});
+
+	describe("OAUTH_PROVIDER_ID", () => {
+		it("matches the legacy provider id `oauth` so existing DB rows + UI translations stay valid", () => {
+			expect(OAUTH_PROVIDER_ID).toBe("oauth");
+		});
+	});
+
+	describe("isOAuthAllowNewUsers()", () => {
+		it("defaults to true (matches pre-migration behaviour)", () => {
+			// biome-ignore lint/performance/noDelete: must actually unset the env key
+			delete process.env.OAUTH_ALLOW_NEW_USERS;
+			expect(isOAuthAllowNewUsers()).toBe(true);
+		});
+
+		it("returns false only when explicitly set to 'false' (case-insensitive)", () => {
+			process.env.OAUTH_ALLOW_NEW_USERS = "false";
+			expect(isOAuthAllowNewUsers()).toBe(false);
+			process.env.OAUTH_ALLOW_NEW_USERS = "FALSE";
+			expect(isOAuthAllowNewUsers()).toBe(false);
+		});
+
+		it("returns true for any other value", () => {
+			process.env.OAUTH_ALLOW_NEW_USERS = "yes";
+			expect(isOAuthAllowNewUsers()).toBe(true);
+			process.env.OAUTH_ALLOW_NEW_USERS = "true";
+			expect(isOAuthAllowNewUsers()).toBe(true);
+		});
+	});
+
+	describe("session config", () => {
+		it("disables cookieCache so isActive/requestChangePassword flips take effect immediately", () => {
+			// If cookieCache is enabled, an admin disabling a user via /api/auth/admin
+			// or our own update mutations would leave the user authenticated for up
+			// to `maxAge` seconds (5 min default). For ztnet that's a security
+			// regression vs. next-auth, which read from DB on every session call.
+			expect(
+				(auth.options.session as { cookieCache?: { enabled?: boolean } })?.cookieCache
+					?.enabled,
+			).toBe(false);
+		});
+	});
+
+	describe("isOAuthExclusiveLogin()", () => {
+		it("defaults to false", () => {
+			// biome-ignore lint/performance/noDelete: must actually unset the env key
+			delete process.env.OAUTH_EXCLUSIVE_LOGIN;
+			expect(isOAuthExclusiveLogin()).toBe(false);
+		});
+
+		it("returns true when explicitly set (case-insensitive)", () => {
+			process.env.OAUTH_EXCLUSIVE_LOGIN = "true";
+			expect(isOAuthExclusiveLogin()).toBe(true);
+			process.env.OAUTH_EXCLUSIVE_LOGIN = "TRUE";
+			expect(isOAuthExclusiveLogin()).toBe(true);
+		});
+	});
+});

--- a/src/server/api/__tests__/services/oauthConfig.test.ts
+++ b/src/server/api/__tests__/services/oauthConfig.test.ts
@@ -21,6 +21,7 @@ import {
 	auth,
 	isOAuthAllowNewUsers,
 	isOAuthExclusiveLogin,
+	oauthCallbackURL,
 } from "~/lib/auth";
 
 describe("OAuth configuration shape", () => {
@@ -37,6 +38,31 @@ describe("OAuth configuration shape", () => {
 	describe("OAUTH_PROVIDER_ID", () => {
 		it("matches the legacy provider id `oauth` so existing DB rows + UI translations stay valid", () => {
 			expect(OAUTH_PROVIDER_ID).toBe("oauth");
+		});
+	});
+
+	describe("oauthCallbackURL()", () => {
+		// THIS IS THE CONTRACT WITH USERS. The URL is documented at
+		// https://ztnet.network/authentication/oauth and registered in every
+		// IdP. Drift here = redirect_uri_mismatch errors at every existing install.
+		it("returns the documented callback URL", () => {
+			process.env.NEXTAUTH_URL = "https://ztnet.example.com";
+			expect(oauthCallbackURL()).toBe(
+				"https://ztnet.example.com/api/auth/callback/oauth",
+			);
+		});
+
+		it("strips a trailing slash from NEXTAUTH_URL so the path is well-formed", () => {
+			process.env.NEXTAUTH_URL = "https://ztnet.example.com/";
+			expect(oauthCallbackURL()).toBe(
+				"https://ztnet.example.com/api/auth/callback/oauth",
+			);
+		});
+
+		it("returns undefined when NEXTAUTH_URL is missing (test/build env)", () => {
+			// biome-ignore lint/performance/noDelete: must actually unset the env key
+			delete process.env.NEXTAUTH_URL;
+			expect(oauthCallbackURL()).toBeUndefined();
 		});
 	});
 

--- a/src/server/api/__tests__/services/oauthPluginConfig.test.ts
+++ b/src/server/api/__tests__/services/oauthPluginConfig.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Pins down the genericOAuth plugin config that gets handed to better-auth.
+ *
+ * `auth.options.plugins[0].options.config[0]` is the actual contract better-auth
+ * sees. If any of these fields drifts, the OAuth flow fails in subtle ways:
+ *   - PKCE off → vulnerable to authorization-code interception attacks AND breaks
+ *     IdPs that require PKCE (Microsoft, modern Keycloak realms).
+ *   - Wrong redirectURI → IdP returns redirect_uri_mismatch.
+ *   - Missing discoveryUrl when OAUTH_WELLKNOWN is set → no discovery, broken setup.
+ *   - Wrong scopes parsing → IdPs reject unknown scope values.
+ *   - Missing trustedProviders → email-verification gating blocks linking when
+ *     OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING is on.
+ *
+ * These tests load `auth` AFTER setting env vars (using jest.isolateModules) so
+ * we can assert different env configurations without polluting the singleton.
+ */
+
+// Snapshot the keys we mutate so we can restore them. Avoid `process.env = {...}`
+// because Node's process.env is a special proxy and full reassignment doesn't
+// propagate cleanly to child requires.
+const ENV_KEYS = [
+	"OAUTH_ID",
+	"OAUTH_SECRET",
+	"OAUTH_WELLKNOWN",
+	"OAUTH_AUTHORIZATION_URL",
+	"OAUTH_ACCESS_TOKEN_URL",
+	"OAUTH_USER_INFO",
+	"OAUTH_SCOPE",
+	"OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING",
+	"OAUTH_ALLOW_NEW_USERS",
+	"OAUTH_EXCLUSIVE_LOGIN",
+	"NEXTAUTH_URL",
+] as const;
+const ENV_BACKUP = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+beforeEach(() => {
+	jest.resetModules();
+	for (const key of ENV_KEYS) {
+		delete process.env[key];
+	}
+});
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(ENV_BACKUP)) {
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+});
+
+function loadAuth() {
+	let exported: typeof import("~/lib/auth") | undefined;
+	jest.isolateModules(() => {
+		exported = require("~/lib/auth");
+	});
+	if (!exported) throw new Error("loadAuth failed");
+	return exported;
+}
+
+function getGenericOAuthConfig() {
+	const { auth } = loadAuth();
+	// biome-ignore lint/suspicious/noExplicitAny: better-auth's BetterAuthOptions['plugins'] is generic
+	const plugins = (auth.options as any).plugins as Array<{
+		id: string;
+		options?: { config?: unknown[] };
+	}>;
+	const generic = plugins.find((p) => p.id === "generic-oauth");
+	return generic?.options?.config?.[0] as Record<string, unknown> | undefined;
+}
+
+describe("genericOAuth plugin: presence", () => {
+	it("registers the plugin when both OAUTH_ID and OAUTH_SECRET are set", () => {
+		process.env.OAUTH_ID = "client_id";
+		process.env.OAUTH_SECRET = "client_secret";
+		process.env.NEXTAUTH_URL = "https://ztnet.example";
+
+		expect(getGenericOAuthConfig()).toBeDefined();
+	});
+
+	it("is NOT registered when OAUTH_ID is empty/falsy", () => {
+		// next/jest reloads .env on resetModules, so `delete` doesn't stick — set
+		// to an empty string instead. `!""` is true, which is what
+		// buildGenericOAuthPlugin guards on.
+		process.env.OAUTH_ID = "";
+		process.env.OAUTH_SECRET = "client_secret";
+		process.env.NEXTAUTH_URL = "https://ztnet.example";
+
+		const { auth } = loadAuth();
+		// biome-ignore lint/suspicious/noExplicitAny: see above
+		const plugins = (auth.options as any).plugins as Array<{ id: string }>;
+		expect(plugins.find((p) => p.id === "generic-oauth")).toBeUndefined();
+	});
+
+	it("is NOT registered when OAUTH_SECRET is empty/falsy", () => {
+		process.env.OAUTH_ID = "client_id";
+		process.env.OAUTH_SECRET = "";
+		process.env.NEXTAUTH_URL = "https://ztnet.example";
+
+		const { auth } = loadAuth();
+		// biome-ignore lint/suspicious/noExplicitAny: see above
+		const plugins = (auth.options as any).plugins as Array<{ id: string }>;
+		expect(plugins.find((p) => p.id === "generic-oauth")).toBeUndefined();
+	});
+});
+
+describe("genericOAuth plugin: required config shape", () => {
+	beforeEach(() => {
+		process.env.OAUTH_ID = "client_id";
+		process.env.OAUTH_SECRET = "client_secret";
+		process.env.NEXTAUTH_URL = "https://ztnet.example";
+	});
+
+	it("uses providerId='oauth' to match the legacy ztnet provider id", () => {
+		expect(getGenericOAuthConfig()?.providerId).toBe("oauth");
+	});
+
+	it("enables PKCE (next-auth had `checks: ['state','pkce']`; better-auth's default is OFF)", () => {
+		expect(getGenericOAuthConfig()?.pkce).toBe(true);
+	});
+
+	it("pins redirectURI to the URL documented at https://ztnet.network/authentication/oauth", () => {
+		expect(getGenericOAuthConfig()?.redirectURI).toBe(
+			"https://ztnet.example/api/auth/callback/oauth",
+		);
+	});
+
+	it("forwards clientId and clientSecret from env", () => {
+		const cfg = getGenericOAuthConfig();
+		expect(cfg?.clientId).toBe("client_id");
+		expect(cfg?.clientSecret).toBe("client_secret");
+	});
+});
+
+describe("genericOAuth plugin: env var → config wiring", () => {
+	beforeEach(() => {
+		process.env.OAUTH_ID = "client_id";
+		process.env.OAUTH_SECRET = "client_secret";
+		process.env.NEXTAUTH_URL = "https://ztnet.example";
+	});
+
+	it("OAUTH_WELLKNOWN → discoveryUrl (OIDC providers like Keycloak / Authentik / Azure)", () => {
+		process.env.OAUTH_WELLKNOWN =
+			"https://idp.example/realms/main/.well-known/openid-configuration";
+		const cfg = getGenericOAuthConfig();
+		expect(cfg?.discoveryUrl).toBe(
+			"https://idp.example/realms/main/.well-known/openid-configuration",
+		);
+		// authorizationUrl/tokenUrl/userInfoUrl can stay undefined — discovery fills them.
+	});
+
+	it("OAUTH_AUTHORIZATION_URL / OAUTH_ACCESS_TOKEN_URL / OAUTH_USER_INFO → standard OAuth 2.0 endpoints", () => {
+		process.env.OAUTH_AUTHORIZATION_URL = "https://github.com/login/oauth/authorize";
+		process.env.OAUTH_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+		process.env.OAUTH_USER_INFO = "https://api.github.com/user";
+
+		const cfg = getGenericOAuthConfig();
+		expect(cfg?.authorizationUrl).toBe("https://github.com/login/oauth/authorize");
+		expect(cfg?.tokenUrl).toBe("https://github.com/login/oauth/access_token");
+		expect(cfg?.userInfoUrl).toBe("https://api.github.com/user");
+	});
+
+	it("OAUTH_SCOPE='read:user user:email' → split into the array better-auth expects", () => {
+		process.env.OAUTH_SCOPE = "read:user user:email";
+		expect(getGenericOAuthConfig()?.scopes).toEqual(["read:user", "user:email"]);
+	});
+
+	// Default-when-unset is covered in `oauthProfileMapping.test.ts` against
+	// `parseOAuthScopes()` directly. We can't repeat it here because next/jest
+	// reloads .env on `resetModules`, putting OAUTH_SCOPE back if it's defined
+	// in the user's local .env file.
+
+	it("`mapProfileToUser` is wired and uses the documented fallback chain", () => {
+		const cfg = getGenericOAuthConfig();
+		const fn = cfg?.mapProfileToUser as (p: Record<string, unknown>) => {
+			name: string;
+			email: unknown;
+		};
+		expect(typeof fn).toBe("function");
+		expect(fn({ login: "x" }).name).toBe("x");
+	});
+});
+
+describe("accountLinking config (OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING)", () => {
+	beforeEach(() => {
+		process.env.OAUTH_ID = "client_id";
+		process.env.OAUTH_SECRET = "client_secret";
+		process.env.NEXTAUTH_URL = "https://ztnet.example";
+	});
+
+	it("enables account linking when OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=true (the historical default)", () => {
+		process.env.OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING = "true";
+		const { auth } = loadAuth();
+		// biome-ignore lint/suspicious/noExplicitAny: better-auth account options
+		expect((auth.options as any).account.accountLinking.enabled).toBe(true);
+	});
+
+	it("disables account linking when OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING=false", () => {
+		process.env.OAUTH_ALLOW_DANGEROUS_EMAIL_LINKING = "false";
+		const { auth } = loadAuth();
+		// biome-ignore lint/suspicious/noExplicitAny: see above
+		expect((auth.options as any).account.accountLinking.enabled).toBe(false);
+	});
+
+	it("lists 'oauth' as a trusted provider so unverified IdP emails can still link", () => {
+		const { auth } = loadAuth();
+		// biome-ignore lint/suspicious/noExplicitAny: see above
+		expect((auth.options as any).account.accountLinking.trustedProviders).toContain(
+			"oauth",
+		);
+	});
+});

--- a/src/server/api/__tests__/services/oauthProfileMapping.test.ts
+++ b/src/server/api/__tests__/services/oauthProfileMapping.test.ts
@@ -1,0 +1,124 @@
+/**
+ * `mapOAuthProfileToUser` runs on every OAuth callback. The fallback chain
+ * matters because each provider documented at
+ * https://ztnet.network/authentication/oauth exposes the user identity through
+ * a different field name. A regression here would either store the wrong
+ * display name or reject the whole sign-in (if email is missing).
+ */
+import { mapOAuthProfileToUser, parseOAuthScopes } from "~/lib/auth";
+
+const SCOPE_BACKUP = process.env.OAUTH_SCOPE;
+
+beforeEach(() => {
+	// biome-ignore lint/performance/noDelete: must actually unset the env key
+	delete process.env.OAUTH_SCOPE;
+});
+
+afterAll(() => {
+	if (SCOPE_BACKUP === undefined) {
+		// biome-ignore lint/performance/noDelete: must actually unset the env key
+		delete process.env.OAUTH_SCOPE;
+	} else {
+		process.env.OAUTH_SCOPE = SCOPE_BACKUP;
+	}
+});
+
+describe("mapOAuthProfileToUser", () => {
+	it("uses `name` when present (Keycloak / Authentik / Azure AD)", () => {
+		expect(
+			mapOAuthProfileToUser({
+				name: "Alice Example",
+				email: "alice@example.com",
+				picture: "https://idp/pic.png",
+			}),
+		).toEqual({
+			name: "Alice Example",
+			email: "alice@example.com",
+			image: "https://idp/pic.png",
+		});
+	});
+
+	it("falls back to `login` for GitHub profiles (which omit `name` for many users)", () => {
+		expect(
+			mapOAuthProfileToUser({
+				login: "alice-gh",
+				email: "alice@example.com",
+				avatar_url: "https://github.com/alice.png",
+			}),
+		).toEqual({
+			name: "alice-gh",
+			email: "alice@example.com",
+			image: "https://github.com/alice.png",
+		});
+	});
+
+	it("falls back to `username` for Discord profiles", () => {
+		expect(
+			mapOAuthProfileToUser({
+				username: "alice#1234",
+				email: "alice@example.com",
+			}),
+		).toMatchObject({ name: "alice#1234" });
+	});
+
+	it("falls back to the email local-part when the profile has no name fields", () => {
+		expect(mapOAuthProfileToUser({ email: "alice@example.com" })).toMatchObject({
+			name: "alice",
+		});
+	});
+
+	it("uses the literal 'OAuth User' as last resort (extreme edge case — IdPs that return no name AND no email)", () => {
+		expect(mapOAuthProfileToUser({})).toMatchObject({ name: "OAuth User" });
+	});
+
+	it("prefers `picture` (OIDC) over `avatar_url` (GitHub) over `image_url`", () => {
+		expect(
+			mapOAuthProfileToUser({
+				name: "x",
+				picture: "p",
+				avatar_url: "a",
+				image_url: "i",
+			}),
+		).toMatchObject({ image: "p" });
+		expect(
+			mapOAuthProfileToUser({ name: "x", avatar_url: "a", image_url: "i" }),
+		).toMatchObject({ image: "a" });
+		expect(mapOAuthProfileToUser({ name: "x", image_url: "i" })).toMatchObject({
+			image: "i",
+		});
+	});
+
+	it("returns image=undefined when the profile has no image fields", () => {
+		expect(mapOAuthProfileToUser({ name: "x", email: "x@y.com" }).image).toBeUndefined();
+	});
+});
+
+describe("parseOAuthScopes", () => {
+	it("defaults to the OIDC trio when OAUTH_SCOPE is unset", () => {
+		jest.replaceProperty(process, "env", { ...process.env });
+		// biome-ignore lint/performance/noDelete: must actually unset the env key
+		delete process.env.OAUTH_SCOPE;
+		expect(parseOAuthScopes()).toEqual(["openid", "profile", "email"]);
+	});
+
+	it("splits a single-spaced value (the canonical form documented for ztnet)", () => {
+		process.env.OAUTH_SCOPE = "openid profile email";
+		expect(parseOAuthScopes()).toEqual(["openid", "profile", "email"]);
+	});
+
+	it("handles GitHub's 'read:user user:email' (colon-containing scopes)", () => {
+		process.env.OAUTH_SCOPE = "read:user user:email";
+		expect(parseOAuthScopes()).toEqual(["read:user", "user:email"]);
+	});
+
+	it("collapses extra whitespace so user typos don't produce empty scopes", () => {
+		// `["", "openid", "", "profile", ""]` would crash the IdP request.
+		process.env.OAUTH_SCOPE = "  openid   profile email ";
+		expect(parseOAuthScopes()).toEqual(["openid", "profile", "email"]);
+	});
+
+	it("supports a single scope (Discord 'identify' or Facebook 'email')", () => {
+		process.env.OAUTH_SCOPE = "email";
+		expect(parseOAuthScopes()).toEqual(["email"]);
+	});
+});

--- a/src/server/api/__tests__/services/passwordSync.test.ts
+++ b/src/server/api/__tests__/services/passwordSync.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Pins down the contract that any password write goes to BOTH `User.hash` AND
+ * `Account.password`. Pre-fix, the tRPC mutations updated only `User.hash`, and
+ * the next sign-in would fail because better-auth verifies against `Account.password`.
+ *
+ * These tests exercise the tRPC `auth` router via `appRouter.createCaller` —
+ * the same surface the frontend uses — so any future mutation that forgets to
+ * call `upsertCredentialAccount` will fail here.
+ */
+import { test, expect, describe, beforeEach } from "@jest/globals";
+
+// Spy on the credential-account service so we can assert it was called.
+jest.mock("~/server/api/services/credentialAccountService", () => ({
+	upsertCredentialAccount: jest.fn(),
+}));
+
+// rate-limit dep imports a real fs module; just stub it.
+jest.mock("~/utils/rateLimit", () => () => ({
+	check: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("~/utils/mail", () => ({
+	sendMailWithTemplate: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("~/utils/encryption", () => ({
+	encrypt: jest.fn(() => "encrypted"),
+	generateInstanceSecret: jest.fn(() => "secret"),
+	API_TOKEN_SECRET: "API_TOKEN_SECRET",
+	PASSWORD_RESET_SECRET: "PASSWORD_RESET_SECRET",
+	VERIFY_EMAIL_SECRET: "VERIFY_EMAIL_SECRET",
+	TOTP_MFA_TOKEN_SECRET: "TOTP_MFA_TOKEN_SECRET",
+}));
+
+// Don't read /var/lib/zerotier-one/authtoken.secret at module load.
+jest.mock("~/utils/ztApi", () => ({
+	ping_api: jest.fn(),
+}));
+
+import { appRouter } from "../../root";
+import type { Session } from "~/lib/authTypes";
+import { PrismaClient } from "@prisma/client";
+import { type PartialDeep } from "type-fest";
+import { upsertCredentialAccount } from "~/server/api/services/credentialAccountService";
+import bcrypt from "bcryptjs";
+
+const mockedUpsert = upsertCredentialAccount as jest.MockedFunction<
+	typeof upsertCredentialAccount
+>;
+
+const session: PartialDeep<Session> = {
+	expires: new Date().toISOString(),
+	user: {
+		id: "user_1",
+		name: "Test User",
+		email: "test@example.com",
+	},
+};
+
+function makePrismaMock(user: Record<string, unknown>): PrismaClient {
+	const prismaMock = new PrismaClient();
+	prismaMock.user.findFirst = jest.fn().mockResolvedValue(user) as never;
+	prismaMock.user.findUnique = jest.fn().mockResolvedValue(user) as never;
+	prismaMock.user.update = jest.fn().mockResolvedValue(user) as never;
+	prismaMock.user.count = jest.fn().mockResolvedValue(1) as never;
+	prismaMock.user.create = jest
+		.fn()
+		.mockResolvedValue({ id: "user_2", name: "x", email: "y" }) as never;
+	prismaMock.userGroup.findFirst = jest.fn().mockResolvedValue(null) as never;
+	prismaMock.globalOptions.findFirst = jest.fn().mockResolvedValue({
+		enableRegistration: true,
+		userRegistrationNotification: false,
+	}) as never;
+	prismaMock.invitation.findUnique = jest.fn() as never;
+	prismaMock.invitation.update = jest.fn() as never;
+	prismaMock.invitation.delete = jest.fn() as never;
+	return prismaMock;
+}
+
+describe("auth router password mutations sync Account.password", () => {
+	beforeEach(() => {
+		mockedUpsert.mockReset();
+		mockedUpsert.mockResolvedValue(undefined);
+	});
+
+	test("auth.update writes the new hash to Account.password", async () => {
+		const oldHash = bcrypt.hashSync("OldPass123!", 10);
+		const prisma = makePrismaMock({
+			id: "user_1",
+			email: "test@example.com",
+			name: "Test",
+			hash: oldHash,
+			accounts: [],
+			requestChangePassword: false,
+		});
+
+		const caller = appRouter.createCaller({
+			session: session as Session,
+			wss: null,
+			prisma,
+			res: { setHeader: jest.fn() } as never,
+			req: { headers: {} } as never,
+		});
+
+		await caller.auth.update({
+			password: "OldPass123!",
+			newPassword: "NewPass123!",
+			repeatNewPassword: "NewPass123!",
+		});
+
+		expect(upsertCredentialAccount).toHaveBeenCalledTimes(1);
+		const [userId, hashArg] = mockedUpsert.mock.calls[0];
+		expect(userId).toBe("user_1");
+		expect(typeof hashArg).toBe("string");
+		// Confirm the synced hash actually validates the new password.
+		expect(bcrypt.compareSync("NewPass123!", hashArg as string)).toBe(true);
+	});
+
+	test("auth.changePasswordFromJwt writes the new hash to Account.password", async () => {
+		// Build a valid token signed by the same secret the router will verify with.
+		const jwt = await import("jsonwebtoken");
+		const token = jwt.sign({ id: "user_1" }, "secret");
+
+		const oldHash = bcrypt.hashSync("OldPass123!", 10);
+		const prisma = makePrismaMock({
+			id: "user_1",
+			email: "test@example.com",
+			name: "Test",
+			hash: oldHash,
+		});
+
+		const caller = appRouter.createCaller({
+			session: null,
+			wss: null,
+			prisma,
+			res: { setHeader: jest.fn() } as never,
+			req: { headers: {} } as never,
+		});
+
+		await caller.auth.changePasswordFromJwt({
+			token,
+			password: "NewPass123!",
+			newPassword: "NewPass123!",
+		});
+
+		expect(upsertCredentialAccount).toHaveBeenCalledTimes(1);
+		const [userId, hashArg] = mockedUpsert.mock.calls[0];
+		expect(userId).toBe("user_1");
+		expect(bcrypt.compareSync("NewPass123!", hashArg as string)).toBe(true);
+	});
+
+	test("auth.register writes the credential Account row for the new user", async () => {
+		const prisma = makePrismaMock({}) as PrismaClient;
+		// register() looks up the user first and must return null.
+		prisma.user.findFirst = jest.fn().mockResolvedValue(null) as never;
+		prisma.user.create = jest.fn().mockResolvedValue({
+			id: "user_new",
+			name: "New",
+			email: "new@example.com",
+			expiresAt: null,
+			role: "USER",
+			memberOfOrgs: [],
+		}) as never;
+
+		const caller = appRouter.createCaller({
+			session: null,
+			wss: null,
+			prisma,
+			res: { setHeader: jest.fn() } as never,
+			req: { headers: {} } as never,
+		});
+
+		await caller.auth.register({
+			email: "new@example.com",
+			password: "BrandNew123!",
+			name: "New",
+		});
+
+		expect(upsertCredentialAccount).toHaveBeenCalledTimes(1);
+		expect(mockedUpsert.mock.calls[0][0]).toBe("user_new");
+	});
+});

--- a/src/server/api/__tests__/services/publicRouterOAuth.test.ts
+++ b/src/server/api/__tests__/services/publicRouterOAuth.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `publicRouter.registrationAllowed` is consumed by the LOGIN page (unauthenticated)
+ * to decide whether to show the "Sign up" link, the email/password form, or the
+ * "Sign in with OAuth" button. If it returns wrong flags, the UI hides legitimate
+ * sign-in paths or shows ones the operator deliberately disabled.
+ *
+ * The router computes `oauthExclusiveLogin` and `oauthAllowNewUsers` from env
+ * vars, and the SAME env-var semantics are used to gate the actual auth flow
+ * (see `isOAuthExclusiveLogin` / `isOAuthAllowNewUsers` in `src/lib/auth.ts`).
+ * This test pins the public-API contract to those env-var defaults.
+ */
+import { test, expect, describe, beforeEach } from "@jest/globals";
+
+jest.mock("~/utils/rateLimit", () => () => ({
+	check: jest.fn().mockResolvedValue(true),
+}));
+jest.mock("~/utils/mail", () => ({
+	sendMailWithTemplate: jest.fn(),
+}));
+jest.mock("~/utils/encryption", () => ({
+	encrypt: jest.fn(),
+	generateInstanceSecret: jest.fn(),
+	API_TOKEN_SECRET: "x",
+	PASSWORD_RESET_SECRET: "x",
+	VERIFY_EMAIL_SECRET: "x",
+	TOTP_MFA_TOKEN_SECRET: "x",
+}));
+jest.mock("~/utils/ztApi", () => ({ ping_api: jest.fn() }));
+
+import { appRouter } from "../../root";
+import { PrismaClient } from "@prisma/client";
+
+const ENV_KEYS = ["OAUTH_EXCLUSIVE_LOGIN", "OAUTH_ALLOW_NEW_USERS"] as const;
+const ENV_BACKUP = Object.fromEntries(ENV_KEYS.map((k) => [k, process.env[k]]));
+
+beforeEach(() => {
+	for (const key of ENV_KEYS) {
+		delete process.env[key];
+	}
+});
+
+afterAll(() => {
+	for (const [key, value] of Object.entries(ENV_BACKUP)) {
+		if (value === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = value;
+		}
+	}
+});
+
+function makeCaller(enableRegistration: boolean) {
+	const prisma = new PrismaClient();
+	prisma.globalOptions.findFirst = jest
+		.fn()
+		.mockResolvedValue({ enableRegistration }) as never;
+
+	return appRouter.createCaller({
+		session: null,
+		wss: null,
+		prisma,
+		res: { setHeader: jest.fn() } as never,
+		req: { headers: {} } as never,
+	});
+}
+
+describe("publicRouter.registrationAllowed", () => {
+	test("returns the three flags in a single shape that matches the LoginPage's expected props", async () => {
+		// Just verify the shape is present + types — the env-var defaults are
+		// covered by `oauthConfig.test.ts` which tests the `is*` helpers directly.
+		// We can't reliably test "OAUTH_ALLOW_NEW_USERS unset" here because
+		// next/jest re-loads .env between test phases.
+		process.env.OAUTH_EXCLUSIVE_LOGIN = "false";
+		process.env.OAUTH_ALLOW_NEW_USERS = "true";
+		const caller = makeCaller(true);
+		const result = await caller.public.registrationAllowed();
+		expect(result).toEqual({
+			enableRegistration: true,
+			oauthExclusiveLogin: false,
+			oauthAllowNewUsers: true,
+		});
+	});
+
+	test("OAUTH_EXCLUSIVE_LOGIN=true is reported to the client (case-insensitive)", async () => {
+		process.env.OAUTH_EXCLUSIVE_LOGIN = "TRUE";
+		const caller = makeCaller(true);
+		const { oauthExclusiveLogin } = await caller.public.registrationAllowed();
+		expect(oauthExclusiveLogin).toBe(true);
+	});
+
+	test("OAUTH_ALLOW_NEW_USERS=false is reported to the client (case-insensitive)", async () => {
+		process.env.OAUTH_ALLOW_NEW_USERS = "FALSE";
+		const caller = makeCaller(true);
+		const { oauthAllowNewUsers } = await caller.public.registrationAllowed();
+		expect(oauthAllowNewUsers).toBe(false);
+	});
+
+	test("when the DB has enableRegistration=false, the flag flows through", async () => {
+		const caller = makeCaller(false);
+		const { enableRegistration } = await caller.public.registrationAllowed();
+		expect(enableRegistration).toBe(false);
+	});
+});

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -25,6 +25,8 @@ import rateLimit from "~/utils/rateLimit";
 import { ErrorCode } from "~/utils/errorCode";
 import { MailTemplateKey } from "~/utils/enums";
 import { mediumPassword, passwordSchema } from "./_schema";
+import { upsertCredentialAccount } from "~/server/api/services/credentialAccountService";
+import { DEVICE_SALT_COOKIE_NAME } from "~/utils/devices";
 
 // Rate limit configuration from environment variables
 // RATE_LIMIT_WINDOW: Time window in minutes (default: 10 minutes)
@@ -285,6 +287,10 @@ export const authRouter = createTRPCRouter({
 				},
 			});
 
+			// Mirror the password into the better-auth credential Account row so the
+			// user can immediately sign in via `authClient.signIn.email`.
+			await upsertCredentialAccount(newUser.id, hash);
+
 			// Send admin notification
 			const globalOptions = await ctx.prisma.globalOptions.findFirst({
 				where: {
@@ -367,11 +373,14 @@ export const authRouter = createTRPCRouter({
 		user.options.urlFromEnv = !!process.env.ZT_ADDR;
 		user.options.secretFromEnv = !!process.env.ZT_SECRET;
 
-		// Read current device ID from cookie for device identification
+		// Read current device ID from cookie for device identification.
+		// Cookie name is preserved across the next-auth → better-auth migration on
+		// purpose (see DEVICE_SALT_COOKIE_NAME); this lookup uses the constant so
+		// the path through the codebase stays consistent.
 		const cookieHeader = ctx.req?.headers?.cookie || "";
 		const deviceCookie = cookieHeader
 			.split(";")
-			.find((c) => c.trim().startsWith("next-auth.did-token="));
+			.find((c) => c.trim().startsWith(`${DEVICE_SALT_COOKIE_NAME}=`));
 		user.currentDeviceId = deviceCookie?.split("=")?.[1]?.trim() || undefined;
 
 		return user;
@@ -415,8 +424,12 @@ export const authRouter = createTRPCRouter({
 			}
 
 			if (input.newPassword || input.repeatNewPassword || input.password) {
-				// Check if user is OAuth user (no existing password)
-				const isOAuthUser = user.accounts && !user.hash;
+				// User authenticates exclusively via OAuth when they have no local
+				// password hash. We check `user.hash` directly — the previous form
+				// (`user.accounts && !user.hash`) was always-truthy on the LHS because
+				// `accounts` is an array, so the OAuth path was never gated on whether
+				// the user actually had any OAuth account rows.
+				const isOAuthUser = !user.hash;
 
 				// For setting new password, all fields are required
 				if (
@@ -458,6 +471,8 @@ export const authRouter = createTRPCRouter({
 				}
 			}
 
+			const newHash = input.newPassword ? bcrypt.hashSync(input.newPassword, 10) : null;
+
 			// update user with new values
 			await ctx.prisma.user.update({
 				where: {
@@ -466,11 +481,18 @@ export const authRouter = createTRPCRouter({
 				data: {
 					email: input.email || user.email,
 					name: input.name || user.name,
-					hash: input.newPassword ? bcrypt.hashSync(input.newPassword, 10) : user.hash,
+					hash: newHash ?? user.hash,
 					// Clear the requestChangePassword flag when user changes password
 					requestChangePassword: input.newPassword ? false : user.requestChangePassword,
 				},
 			});
+
+			// Keep the better-auth credential Account row in sync. better-auth
+			// authenticates against `Account.password` (not `User.hash`); without this
+			// the user's next sign-in would silently fail with "invalid credentials".
+			if (newHash) {
+				await upsertCredentialAccount(user.id, newHash);
+			}
 		}),
 	validateResetPasswordToken: publicProcedure
 		.input(
@@ -627,15 +649,24 @@ export const authRouter = createTRPCRouter({
 				const secret = generateInstanceSecret(PASSWORD_RESET_SECRET);
 				jwt.verify(token, secret);
 
-				// hash password
-				return await ctx.prisma.user.update({
+				const newHash = bcrypt.hashSync(password, 10);
+
+				const updated = await ctx.prisma.user.update({
 					where: {
 						id,
 					},
 					data: {
-						hash: bcrypt.hashSync(password, 10),
+						hash: newHash,
+						// Forced-reset implies the user just remembered/picked a fresh password —
+						// clear the must-change-on-next-login flag if it was set.
+						requestChangePassword: false,
 					},
 				});
+
+				// Mirror into the better-auth credential Account so /sign-in/email succeeds.
+				await upsertCredentialAccount(id, newHash);
+
+				return updated;
 			} catch (error) {
 				console.error(error);
 				throwError("token is not valid, please try again!");

--- a/src/server/api/services/credentialAccountService.ts
+++ b/src/server/api/services/credentialAccountService.ts
@@ -1,0 +1,35 @@
+import { prisma } from "~/server/db";
+
+/**
+ * Keep `Account` (better-auth's credential store, where `providerId="credential"`)
+ * in sync with `User.hash` whenever a password is written.
+ *
+ * better-auth verifies passwords on sign-in by reading `Account.password` for the
+ * row with `providerId="credential"` (see better-auth's `/sign-in/email` handler).
+ * If we only update `User.hash`, the next login fails because the two stores drift.
+ *
+ * Use this any time `User.hash` is written from outside better-auth (registration,
+ * password reset, profile-page password change).
+ */
+export async function upsertCredentialAccount(
+	userId: string,
+	passwordHash: string,
+): Promise<void> {
+	await prisma.account.upsert({
+		where: {
+			providerId_accountId: {
+				providerId: "credential",
+				accountId: userId,
+			},
+		},
+		create: {
+			userId,
+			accountId: userId,
+			providerId: "credential",
+			password: passwordHash,
+		},
+		update: {
+			password: passwordHash,
+		},
+	});
+}


### PR DESCRIPTION
Post-migration audit caught several regressions. All fixes validated against better-auth@1.6.9 source and the OAuth contract at https://ztnet.network/authentication/oauth.