### PR TITLE
Fix: prevent modifying stashed members via API, add deleted:false restore

### DIFF
--- a/docs/docs/Rest Api/Organization/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Organization/_source/networkMember.yml
@@ -98,6 +98,8 @@ paths:
       summary: Modify a organization network member
       description: |
         Modify a organization network member. This endpoint can also be used to pre-authorize a member that has not yet joined the network by providing their ZeroTier node ID as the `memberId`. If the member does not yet exist in the database, it will be created on the ZeroTier controller and returned in the response.
+
+        A stashed (deleted) member cannot be modified. Attempting to do so returns `409 Conflict`. To restore a stashed member, send `deleted: false` (optionally together with the other fields you want to update in the same request).
       parameters:
         - in: path
           name: networkId
@@ -156,6 +158,10 @@ paths:
                         description: Tag key
                       - type: string
                         description: Tag value
+                deleted:
+                  type: boolean
+                  description: |
+                    Set to `false` to restore a stashed (deleted) member. Only `false` is accepted; use the DELETE method to stash a member.
               # required:
               #   - name
               #   - authorized
@@ -173,6 +179,18 @@ paths:
                 $ref: '../../_example/NetworkMemberExample.yml#/NetworkArrayMemberExample'
         401:
           $ref: '../../_http_responses/Unauthorized.yml#/Unauthorized'
+        409:
+          description: |
+            The member is stashed (deleted) and cannot be modified. Send `deleted: false` to restore it before modifying.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              example:
+                error: "Member is deleted. Set `deleted: false` to restore the member before modifying it."
         429:
           $ref: '../../_http_responses/RateLimitExceeded.yml#/RateLimitExceeded'
         500:

--- a/docs/docs/Rest Api/Organization/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Organization/_source/networkMember.yml
@@ -160,8 +160,9 @@ paths:
                         description: Tag value
                 deleted:
                   type: boolean
+                  enum: [false]
                   description: |
-                    Set to `false` to restore a stashed (deleted) member. Only `false` is accepted; use the DELETE method to stash a member.
+                    Set to `false` to restore a stashed (deleted) member. Only `false` is accepted; `deleted: true` returns `400` (use the DELETE method to stash a member).
               # required:
               #   - name
               #   - authorized

--- a/docs/docs/Rest Api/Personal/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Personal/_source/networkMember.yml
@@ -54,6 +54,8 @@ paths:
       summary: Modify a network member
       description: |
         Modify a network member. This endpoint can also be used to pre-authorize a member that has not yet joined the network by providing their ZeroTier node ID as the `memberId`. If the member does not yet exist in the database, it will be created on the ZeroTier controller and returned in the response.
+
+        A stashed (deleted) member cannot be modified. Attempting to do so returns `409 Conflict`. To restore a stashed member, send `deleted: false` (optionally together with the other fields you want to update in the same request).
       parameters:
         - in: path
           name: networkId
@@ -80,6 +82,10 @@ paths:
                 authorized:
                   type: boolean
                   description: Authorization status of the member
+                deleted:
+                  type: boolean
+                  description: |
+                    Set to `false` to restore a stashed (deleted) member. Only `false` is accepted; use the DELETE method to stash a member.
               # required:
               #   - name
               #   - authorized
@@ -97,6 +103,18 @@ paths:
                 $ref: '../../_example/NetworkMemberExample.yml#/NetworkArrayMemberExample'
         401:
           $ref: '../../_http_responses/Unauthorized.yml#/Unauthorized'
+        409:
+          description: |
+            The member is stashed (deleted) and cannot be modified. Send `deleted: false` to restore it before modifying.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+              example:
+                error: "Member is deleted. Set `deleted: false` to restore the member before modifying it."
         429:
           $ref: '../../_http_responses/RateLimitExceeded.yml#/RateLimitExceeded'
         500:

--- a/docs/docs/Rest Api/Personal/_source/networkMember.yml
+++ b/docs/docs/Rest Api/Personal/_source/networkMember.yml
@@ -84,8 +84,9 @@ paths:
                   description: Authorization status of the member
                 deleted:
                   type: boolean
+                  enum: [false]
                   description: |
-                    Set to `false` to restore a stashed (deleted) member. Only `false` is accepted; use the DELETE method to stash a member.
+                    Set to `false` to restore a stashed (deleted) member. Only `false` is accepted; `deleted: true` returns `400` (use the DELETE method to stash a member).
               # required:
               #   - name
               #   - authorized

--- a/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
+++ b/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
@@ -134,6 +134,97 @@ describe("Update Network Members", () => {
 		expect(res.status).toHaveBeenCalledWith(200);
 	});
 
+	it("should respond 409 when modifying a stashed (deleted) member", async () => {
+		prisma.network.findUnique = jest.fn().mockResolvedValue({
+			nwid: "test_nw_id",
+			nwname: "credent_second",
+			authorId: "userId",
+			networkMembers: [{ id: "memberId", deleted: true }],
+		});
+
+		const req = {
+			method: "POST",
+			headers: { "x-ztnet-auth": "validApiKey" },
+			query: { id: "networkId", memberId: "memberId" },
+			body: { authorized: true },
+		} as unknown as NextApiRequest;
+
+		const res = createMockRes();
+
+		await apiNetworkUpdateMembersHandler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(409);
+		// Controller must not be touched when the request is rejected.
+		expect(ztController.member_update).not.toHaveBeenCalled();
+	});
+
+	it("should restore a stashed member when deleted:false is sent", async () => {
+		prisma.network.findUnique = jest.fn().mockResolvedValue({
+			nwid: "test_nw_id",
+			nwname: "credent_second",
+			authorId: "userId",
+			networkMembers: [{ id: "memberId", deleted: true }],
+		});
+
+		prisma.network_members.findUnique = jest.fn().mockResolvedValue({
+			id: "memberId",
+			authorized: true,
+			deleted: false,
+		});
+
+		(ztController.member_details as jest.Mock).mockResolvedValue([]);
+
+		const req = {
+			method: "POST",
+			headers: { "x-ztnet-auth": "validApiKey" },
+			query: { id: "networkId", memberId: "memberId" },
+			body: { authorized: true, deleted: false },
+		} as unknown as NextApiRequest;
+
+		const res = createMockRes();
+
+		await apiNetworkUpdateMembersHandler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(200);
+		// The database update must clear both deletion flags.
+		expect(prisma.network.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					networkMembers: expect.objectContaining({
+						update: expect.objectContaining({
+							data: expect.objectContaining({
+								deleted: false,
+								permanentlyDeleted: false,
+							}),
+						}),
+					}),
+				}),
+			}),
+		);
+	});
+
+	it("should reject deleted:true with 400", async () => {
+		prisma.network.findUnique = jest.fn().mockResolvedValue({
+			nwid: "test_nw_id",
+			nwname: "credent_second",
+			authorId: "userId",
+			networkMembers: [{ id: "memberId" }],
+		});
+
+		const req = {
+			method: "POST",
+			headers: { "x-ztnet-auth": "validApiKey" },
+			query: { id: "networkId", memberId: "memberId" },
+			body: { deleted: true },
+		} as unknown as NextApiRequest;
+
+		const res = createMockRes();
+
+		await apiNetworkUpdateMembersHandler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(400);
+	});
+
 	it("should respond 401 for invalid input", async () => {
 		// Mock the database to return a network
 		prisma.network.findUnique = jest.fn().mockResolvedValue({

--- a/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
+++ b/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
@@ -134,6 +134,53 @@ describe("Update Network Members", () => {
 		expect(res.status).toHaveBeenCalledWith(200);
 	});
 
+	it("should persist name to the database and controller (issue #929)", async () => {
+		prisma.network.findUnique = jest.fn().mockResolvedValue({
+			nwid: "test_nw_id",
+			nwname: "credent_second",
+			authorId: "userId",
+			networkMembers: [{ id: "memberId" }],
+		});
+
+		prisma.network_members.findUnique = jest.fn().mockResolvedValue({
+			id: "memberId",
+			name: "New Name",
+		});
+
+		(ztController.member_details as jest.Mock).mockResolvedValue([]);
+
+		const req = {
+			method: "POST",
+			headers: { "x-ztnet-auth": "validApiKey" },
+			query: { id: "networkId", memberId: "memberId" },
+			body: { name: "New Name" },
+		} as unknown as NextApiRequest;
+
+		const res = createMockRes();
+
+		await apiNetworkUpdateMembersHandler(req, res);
+
+		expect(res.status).toHaveBeenCalledWith(200);
+		// name must be written to the database, not only the controller.
+		expect(prisma.network.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					networkMembers: expect.objectContaining({
+						update: expect.objectContaining({
+							data: expect.objectContaining({ name: "New Name" }),
+						}),
+					}),
+				}),
+			}),
+		);
+		// and still sent to the controller to keep both stores in sync.
+		expect(ztController.member_update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				updateParams: expect.objectContaining({ name: "New Name" }),
+			}),
+		);
+	});
+
 	it("should respond 409 when modifying a stashed (deleted) member", async () => {
 		prisma.network.findUnique = jest.fn().mockResolvedValue({
 			nwid: "test_nw_id",

--- a/src/pages/api/v1/network/[id]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/_schema.ts
@@ -7,8 +7,9 @@ export const updateableFieldsMetaSchema = z
 		name: z.string().optional(),
 		description: z.string().optional(),
 		authorized: z.boolean().optional(),
-		// Restore a stashed (deleted) member. Only `false` is accepted; use the
-		// DELETE method to stash a member.
+		// Restore a stashed (deleted) member with `deleted: false`. A boolean is
+		// parsed here, but `deleted: true` is rejected by the handler with a 400
+		// (use the DELETE method to stash a member).
 		deleted: z.boolean().optional(),
 	})
 	.strict();

--- a/src/pages/api/v1/network/[id]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/_schema.ts
@@ -7,6 +7,9 @@ export const updateableFieldsMetaSchema = z
 		name: z.string().optional(),
 		description: z.string().optional(),
 		authorized: z.boolean().optional(),
+		// Restore a stashed (deleted) member. Only `false` is accepted; use the
+		// DELETE method to stash a member.
+		deleted: z.boolean().optional(),
 	})
 	.strict();
 

--- a/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
@@ -76,11 +76,23 @@ const POST_updateNetworkMember = SecuredPrivateApiRoute(
 			return res.status(400).json({ error: "No data provided for update" });
 		}
 
+		// The `deleted` field is handled explicitly below, not through the generic
+		// updateable-field loop. Sending `deleted: false` restores a stashed member;
+		// `deleted: true` is rejected (use the DELETE method to stash a member).
+		if (validatedInput.deleted === true) {
+			return res.status(400).json({
+				error:
+					"Setting `deleted: true` is not supported. Use the DELETE method to stash a member.",
+			});
+		}
+		const restoreRequested = validatedInput.deleted === false;
+
 		const databasePayload: Partial<network_members> = {};
 		const controllerPayload: Partial<network_members> = {};
 
 		// Iterate over keys in the request body
 		for (const [key, value] of Object.entries(validatedInput)) {
+			if (key === "deleted") continue;
 			try {
 				if (updateableFields[key].destinations.includes("database")) {
 					databasePayload[key] = value;
@@ -105,6 +117,23 @@ const POST_updateNetworkMember = SecuredPrivateApiRoute(
 			});
 
 			const dbMember = network?.networkMembers?.[0];
+
+			// A stashed (deleted) member cannot be modified unless the request
+			// explicitly restores it with `deleted: false`. This prevents the
+			// inconsistent state where a member is authorized on the controller while
+			// still flagged as deleted in the database (see issue #930).
+			if (dbMember?.deleted && !restoreRequested) {
+				return res.status(409).json({
+					error:
+						"Member is deleted. Set `deleted: false` to restore the member before modifying it.",
+				});
+			}
+
+			// Restore the member in the database when requested.
+			if (restoreRequested) {
+				databasePayload.deleted = false;
+				databasePayload.permanentlyDeleted = false;
+			}
 
 			if (dbMember && Object.keys(databasePayload).length > 0) {
 				await ctx.prisma.network.update({

--- a/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
@@ -67,7 +67,7 @@ const POST_updateNetworkMember = SecuredPrivateApiRoute(
 		const validatedInput = updateableFieldsMetaSchema.parse(body);
 
 		const updateableFields = {
-			name: { type: "string", destinations: ["controller"] },
+			name: { type: "string", destinations: ["database", "controller"] },
 			description: { type: "string", destinations: ["database"] },
 			authorized: { type: "boolean", destinations: ["controller"] },
 		};

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
@@ -13,6 +13,9 @@ export const PostBodySchema = z
 		noAutoAssignIps: z.boolean().optional(),
 		ssoExempt: z.boolean().optional(),
 		tags: z.array(z.tuple([z.number(), z.number()])).optional(),
+		// Restore a stashed (deleted) member. Only `false` is accepted; use the
+		// DELETE method to stash a member.
+		deleted: z.boolean().optional(),
 	})
 	.strict();
 

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/_schema.ts
@@ -13,8 +13,9 @@ export const PostBodySchema = z
 		noAutoAssignIps: z.boolean().optional(),
 		ssoExempt: z.boolean().optional(),
 		tags: z.array(z.tuple([z.number(), z.number()])).optional(),
-		// Restore a stashed (deleted) member. Only `false` is accepted; use the
-		// DELETE method to stash a member.
+		// Restore a stashed (deleted) member with `deleted: false`. A boolean is
+		// parsed here, but `deleted: true` is rejected by the handler with a 400
+		// (use the DELETE method to stash a member).
 		deleted: z.boolean().optional(),
 	})
 	.strict();

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -66,7 +66,7 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 			// structure of the updateableFields object:
 
 			const updateableFields = {
-				name: { type: "string", destinations: ["database"] },
+				name: { type: "string", destinations: ["database", "controller"] },
 				authorized: { type: "boolean", destinations: ["controller"] },
 				activeBridge: { type: "boolean", destinations: ["controller"] },
 				capabilities: { type: "array", destinations: ["controller"] },

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -76,11 +76,23 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 				tags: { type: "array", destinations: ["controller"] },
 			};
 
+			// The `deleted` field is handled explicitly below, not through the generic
+			// updateable-field loop. Sending `deleted: false` restores a stashed
+			// member; `deleted: true` is rejected (use the DELETE method to stash).
+			if (validatedBody.deleted === true) {
+				return res.status(400).json({
+					error:
+						"Setting `deleted: true` is not supported. Use the DELETE method to stash a member.",
+				});
+			}
+			const restoreRequested = validatedBody.deleted === false;
+
 			const databasePayload: Partial<network_members> = {};
 			const controllerPayload: Partial<network_members> = {};
 
 			// Iterate over keys in the request body
 			for (const [key, value] of Object.entries(validatedBody)) {
+				if (key === "deleted") continue;
 				// Check if the key is not in updateableFields
 				if (!(key in updateableFields)) {
 					return res.status(400).json({ error: `Invalid field: ${key}` });
@@ -129,6 +141,23 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 				return res.status(404).json({ error: "Network not found or access denied." });
 			}
 			const dbMember = network.networkMembers?.[0];
+
+			// A stashed (deleted) member cannot be modified unless the request
+			// explicitly restores it with `deleted: false`. This prevents the
+			// inconsistent state where a member is authorized on the controller while
+			// still flagged as deleted in the database (see issue #930).
+			if (dbMember?.deleted && !restoreRequested) {
+				return res.status(409).json({
+					error:
+						"Member is deleted. Set `deleted: false` to restore the member before modifying it.",
+				});
+			}
+
+			// Restore the member in the database when requested.
+			if (restoreRequested) {
+				databasePayload.deleted = false;
+				databasePayload.permanentlyDeleted = false;
+			}
 
 			if (dbMember) {
 				// Member exists in DB, update if there are database fields to update


### PR DESCRIPTION
Fixes #929 and #930 in both the personal and org member-update endpoints.

- **#929:** `name` was sent to the controller only, so the UI/DB kept the old name. Now routed to both DB and controller, matching the UI path.
- **#930:** modifying a deleted member left it authorized-but-hidden. Now returns `409`; send `deleted: false` to restore.