### PR TITLE
DB-first member sync + live WebSocket updates

### DIFF
--- a/prisma/migrations/20260626085020_member_db_cache/migration.sql
+++ b/prisma/migrations/20260626085020_member_db_cache/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "network_members" ADD COLUMN     "activeBridge" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "ipAssignments" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "noAutoAssignIps" BOOLEAN NOT NULL DEFAULT false,
+ADD COLUMN     "revision" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -95,6 +95,12 @@ model network_members {
   description        String?
   address            String?                 @default("")
   creationTime       DateTime
+  // Cached controller config (source of truth = controller; reconciled via revision).
+  // Lets the member list render from the DB without an N+1 controller fetch per load.
+  ipAssignments      String[]                @default([])
+  noAutoAssignIps    Boolean                 @default(false)
+  activeBridge       Boolean                 @default(false)
+  revision           Int?
   notations          NetworkMemberNotation[]
 
   @@unique([id, nwid])

--- a/src/__tests__/__mocks__/networkById.ts
+++ b/src/__tests__/__mocks__/networkById.ts
@@ -132,6 +132,13 @@ jest.mock("../../utils/api", () => ({
 					refetch: jest.fn(),
 				}),
 			},
+			getNetworkMembers: {
+				useQuery: () => ({
+					data: { members: [], totalCount: 0, authorizedCount: 0 },
+					isLoading: false,
+					refetch: jest.fn(),
+				}),
+			},
 			updateNetwork: {
 				useMutation: () => ({
 					mutate: jest.fn(),

--- a/src/__tests__/pages/network/[id].test.tsx
+++ b/src/__tests__/pages/network/[id].test.tsx
@@ -66,6 +66,12 @@ jest.mock("~/lib/authSession", () => ({
 jest.mock("next/router", () => ({
 	useRouter: jest.fn(),
 }));
+// The members table opens a Socket.IO connection for live updates; stub it in tests.
+jest.mock("~/hooks/useNetworkMembersSocket", () => ({
+	__esModule: true,
+	useNetworkMembersSocket: jest.fn(),
+	default: jest.fn(),
+}));
 describe("NetworkById component", () => {
 	beforeAll(() => {
 		process.env.NEXT_PUBLIC_NODE_ENV = "test";

--- a/src/__tests__/pages/network/[id].test.tsx
+++ b/src/__tests__/pages/network/[id].test.tsx
@@ -133,6 +133,16 @@ describe("NetworkById component", () => {
 			refetch: jest.fn(),
 		});
 		api.network.getNetworkById.useQuery = useQueryMock;
+		// The members table reads from the paginated endpoint; feed it the same rows.
+		api.network.getNetworkMembers.useQuery = jest.fn().mockReturnValue({
+			data: {
+				members: useQueryMock().data.members ?? [],
+				totalCount: (useQueryMock().data.members ?? []).length,
+				authorizedCount: 0,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+		});
 
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -249,11 +259,22 @@ describe("NetworkById component", () => {
 						conStatus: 0,
 					},
 				],
+				memberCount: 1,
 			},
 			isLoading: false,
 			refetch: jest.fn(),
 		});
 		api.network.getNetworkById.useQuery = useQueryMock;
+		// The members table reads from the paginated endpoint; feed it the same rows.
+		api.network.getNetworkMembers.useQuery = jest.fn().mockReturnValue({
+			data: {
+				members: useQueryMock().data.members ?? [],
+				totalCount: (useQueryMock().data.members ?? []).length,
+				authorizedCount: 0,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+		});
 
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -297,12 +318,23 @@ describe("NetworkById component", () => {
 						conStatus: ConnectionStatus.DirectWAN,
 					},
 				],
+				memberCount: 1,
 			},
 			isLoading: false,
 			refetch: jest.fn(),
 		});
 
 		api.network.getNetworkById.useQuery = useQueryMock;
+		// The members table reads from the paginated endpoint; feed it the same rows.
+		api.network.getNetworkMembers.useQuery = jest.fn().mockReturnValue({
+			data: {
+				members: useQueryMock().data.members ?? [],
+				totalCount: (useQueryMock().data.members ?? []).length,
+				authorizedCount: 0,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+		});
 
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -338,12 +370,23 @@ describe("NetworkById component", () => {
 						conStatus: ConnectionStatus.Relayed,
 					},
 				],
+				memberCount: 1,
 			},
 			isLoading: false,
 			refetch: jest.fn(),
 		});
 
 		api.network.getNetworkById.useQuery = useQueryMock;
+		// The members table reads from the paginated endpoint; feed it the same rows.
+		api.network.getNetworkMembers.useQuery = jest.fn().mockReturnValue({
+			data: {
+				members: useQueryMock().data.members ?? [],
+				totalCount: (useQueryMock().data.members ?? []).length,
+				authorizedCount: 0,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+		});
 
 		render(
 			<QueryClientProvider client={queryClient}>
@@ -379,12 +422,22 @@ describe("NetworkById component", () => {
 						conStatus: ConnectionStatus.Offline,
 					},
 				],
+				memberCount: 1,
 			},
 			isLoading: false,
 			refetch: jest.fn(),
 		});
 
 		api.network.getNetworkById.useQuery = useQueryMock;
+		api.network.getNetworkMembers.useQuery = jest.fn().mockReturnValue({
+			data: {
+				members: useQueryMock().data.members ?? [],
+				totalCount: (useQueryMock().data.members ?? []).length,
+				authorizedCount: 0,
+			},
+			isLoading: false,
+			refetch: jest.fn(),
+		});
 		render(
 			<QueryClientProvider client={queryClient}>
 				<NextIntlClientProvider locale="en" messages={enTranslation}>

--- a/src/components/networkByIdPage/addMemberById.tsx
+++ b/src/components/networkByIdPage/addMemberById.tsx
@@ -39,6 +39,7 @@ export const AddMemberById = ({ central = false, organizationId }: IProp) => {
 				nwid: query.id as string,
 				central,
 			});
+			await utils.network.getNetworkMembers.invalidate();
 			handleApiSuccess({ actions: [refecthNetworkById] })();
 		},
 		onError: handleApiError,

--- a/src/components/networkByIdPage/memberOptionsModal.tsx
+++ b/src/components/networkByIdPage/memberOptionsModal.tsx
@@ -42,6 +42,8 @@ export const MemberOptionsModal: React.FC<ModalContentProps> = ({
 	const [ipAssignments, seIpAssignments] = useState<string[]>([]);
 
 	const { query } = useRouter();
+	const utils = api.useUtils();
+	const refetchMembersTable = () => void utils.network.getNetworkMembers.invalidate();
 
 	const { data: networkById, refetch: refetchNetworkById } =
 		api.network.getNetworkById.useQuery(
@@ -73,20 +75,17 @@ export const MemberOptionsModal: React.FC<ModalContentProps> = ({
 		);
 
 	useEffect(() => {
-		// Check if members is an array and the first member has an 'id' property
-		if (Array.isArray(networkById?.members) && networkById.members[0]?.id) {
-			const member = (networkById.members as MemberEntity[]).find(
-				(member) => member.id === memberId,
-			);
-
-			seIpAssignments(member?.ipAssignments || []);
-		}
-	}, [networkById?.members, memberId]);
+		// IP assignments come from the per-member detail query (controller-live),
+		// not from the network member list.
+		seIpAssignments(memberById?.ipAssignments || []);
+	}, [memberById?.ipAssignments]);
 
 	const { mutate: updateMember, isLoading: updateMemberLoading } =
 		api.networkMember.Update.useMutation({
 			onError: handleApiError,
-			onSuccess: handleApiSuccess({ actions: [refetchNetworkById, refetchMemberById] }),
+			onSuccess: handleApiSuccess({
+				actions: [refetchNetworkById, refetchMemberById, refetchMembersTable],
+			}),
 		});
 
 	// const stashMember = (id: string) => {

--- a/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
+++ b/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
@@ -90,7 +90,15 @@ export const NetworkRoutesTable = React.memo(
 					enabled: !!query.id,
 				},
 			);
-		const { network, members } = networkById || {};
+		const { network } = networkById || {};
+
+		// Members (for route node-name resolution) come from the dedicated DB-first
+		// endpoint now; request all in one page.
+		const { data: membersData } = api.network.getNetworkMembers.useQuery(
+			{ nwid: query.id as string, central, pageSize: 100000 },
+			{ enabled: !!query.id },
+		);
+		const members = membersData?.members ?? [];
 
 		const { mutate: updateManageRoutes, isLoading: isUpdating } =
 			api.network.managedRoutes.useMutation({

--- a/src/components/networkByIdPage/table/members/DeletedMembersTable.tsx
+++ b/src/components/networkByIdPage/table/members/DeletedMembersTable.tsx
@@ -38,6 +38,7 @@ export const DeletedNetworkMembersTable = ({ nwid, organizationId }: IProps) => 
 			nwid: nwid as string,
 			central: false,
 		});
+		await utils.network.getNetworkMembers.invalidate();
 		void refetchNetworkById();
 	};
 

--- a/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
+++ b/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
@@ -2,16 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	useReactTable,
 	getCoreRowModel,
-	getPaginationRowModel,
-	getSortedRowModel,
-	getFilteredRowModel,
 	flexRender,
 	type RowData,
+	type PaginationState,
 } from "@tanstack/react-table";
 import { api } from "~/utils/api";
 import { useRouter } from "next/router";
-import { useSkipper } from "~/hooks/useSkipper";
 import { convertRGBtoRGBA } from "~/utils/randomColor";
+import { getLocalStorageItem } from "~/utils/localstorage";
 import TableFooter from "~/components/shared/tableFooter";
 import { type NetworkEntity } from "~/types/local/network";
 import { useMemberColumns } from "./useMemberColumns";
@@ -24,8 +22,7 @@ declare module "@tanstack/react-table" {
 	interface TableMeta<TData extends RowData> {
 		updateData: (rowIndex: number, columnId: string, value: unknown) => void;
 		// Live data read by cells at render time (so columns stay stable across
-		// refetches and cells avoid per-row query subscriptions). Optional because
-		// this TableMeta augmentation is global to every table in the app.
+		// refetches and cells avoid per-row query subscriptions).
 		network?: NetworkEntity;
 		deAuthorizeWarning?: boolean;
 		showNotationMarker?: boolean;
@@ -38,6 +35,9 @@ interface IProp {
 	organizationId?: string;
 }
 
+// Columns the server can sort on (others are computed/array and disable sorting).
+const SERVER_SORTABLE = new Set(["id", "name", "authorized", "physicalAddress"]);
+
 export const NetworkMembersTable = ({ nwid, central = false, organizationId }: IProp) => {
 	const { query } = useRouter();
 	const [globalFilter, setGlobalFilter] = useState("");
@@ -49,23 +49,54 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 		columnVisibility,
 		setColumnVisibility,
 	} = useTablePersistence();
+	const [pagination, setPagination] = useState<PaginationState>(() => ({
+		pageIndex: 0,
+		pageSize: getLocalStorageItem("pageSize-NetworkMembersTable", 10),
+	}));
 
-	const { data: networkById, isLoading: loadingNetworks } =
-		api.network.getNetworkById.useQuery({ nwid, central }, { enabled: !!query.id });
-
+	// Network metadata (routes/v6 modes) + user options are shared (deduped) with
+	// the page's query; members come from the paginated, DB-first endpoint.
+	const { data: networkById } = api.network.getNetworkById.useQuery(
+		{ nwid, central },
+		{ enabled: !!query.id },
+	);
 	const { data: me } = api.auth.me.useQuery();
 
-	const memoizedMembers = useMemo(
-		() => networkById?.members ?? [],
-		[networkById?.members],
+	const activeSort = sorting[0];
+	const sortBy = activeSort && SERVER_SORTABLE.has(activeSort.id) ? activeSort.id : "id";
+	const sortDir = activeSort?.desc ? "desc" : "asc";
+
+	const { data: membersData, isLoading } = api.network.getNetworkMembers.useQuery(
+		{
+			nwid,
+			central,
+			page: pagination.pageIndex,
+			pageSize: pagination.pageSize,
+			search: globalFilter || undefined,
+			// biome-ignore lint/suspicious/noExplicitAny: narrowed to the server enum above
+			sortBy: sortBy as any,
+			sortDir,
+		},
+		{ enabled: !!query.id, refetchInterval: 10000 },
 	);
 
-	const [data, setData] = useState(networkById?.members ?? []);
+	const totalCount = membersData?.totalCount ?? 0;
+	const memoizedMembers = useMemo(
+		() => membersData?.members ?? [],
+		[membersData?.members],
+	);
 
-	// Background polling refreshes member data every 10s. Applying that refresh
-	// while a user is editing an inline cell rebuilds the row and drops focus, so
-	// we freeze updates while any editor is focused and flush the latest snapshot
-	// once editing ends.
+	// Reset to the first page whenever the filter or sort changes (these are
+	// triggers, not values read in the effect).
+	// biome-ignore lint/correctness/useExhaustiveDependencies: intentional triggers
+	useEffect(() => {
+		setPagination((p) => ({ ...p, pageIndex: 0 }));
+	}, [globalFilter, sorting]);
+
+	// Mirror the fetched page into local state, but freeze updates while an inline
+	// editor is focused so a background refetch never rebuilds the row being typed
+	// in. The latest snapshot is flushed when editing ends.
+	const [data, setData] = useState(memoizedMembers);
 	const editingCountRef = useRef(0);
 	const pendingDataRef = useRef<typeof memoizedMembers | null>(null);
 
@@ -91,21 +122,22 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 		organizationId,
 		onEditingChange: handleEditingChange,
 	});
-	const [autoResetPageIndex, skipAutoResetPageIndex] = useSkipper();
 
 	const table = useReactTable({
 		data,
 		columns,
+		state: { pagination, sorting, globalFilter, columnVisibility },
+		manualPagination: true,
+		manualSorting: true,
+		manualFiltering: true,
+		pageCount: Math.max(1, Math.ceil(totalCount / Math.max(1, pagination.pageSize))),
+		onPaginationChange: setPagination,
 		onSortingChange: setSorting,
-		getCoreRowModel: getCoreRowModel(),
-		getSortedRowModel: getSortedRowModel(),
-		getPaginationRowModel: getPaginationRowModel(),
-		autoResetPageIndex,
-		state: { sorting, globalFilter, columnVisibility },
+		onGlobalFilterChange: setGlobalFilter,
 		onColumnVisibilityChange: setColumnVisibility,
+		getCoreRowModel: getCoreRowModel(),
 		meta: {
 			updateData: (rowIndex, columnId, value) => {
-				skipAutoResetPageIndex();
 				setData((old = []) =>
 					old.map((row, index) =>
 						index === rowIndex ? { ...old[rowIndex]!, [columnId]: value } : row,
@@ -116,12 +148,9 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 			deAuthorizeWarning: !!me?.options?.deAuthorizeWarning,
 			showNotationMarker: !!me?.options?.showNotationMarkerInTableRow,
 		},
-		onGlobalFilterChange: setGlobalFilter,
-		getFilteredRowModel: getFilteredRowModel(),
-		debugTable: false,
 	});
 
-	if (loadingNetworks) return <div>Loading</div>;
+	if (isLoading && data.length === 0) return <div>Loading</div>;
 
 	const useNotationBg = !central && me?.options?.useNotationColorAsBg;
 
@@ -222,7 +251,7 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 				</table>
 			</div>
 			<div className="flex flex-col items-center justify-between py-3 sm:flex-row">
-				<TableFooter table={table} page="NetworkMembersTable" />
+				<TableFooter table={table} page="NetworkMembersTable" totalCount={totalCount} />
 			</div>
 		</div>
 	);

--- a/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
+++ b/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
@@ -12,6 +12,7 @@ import { convertRGBtoRGBA } from "~/utils/randomColor";
 import { getLocalStorageItem } from "~/utils/localstorage";
 import TableFooter from "~/components/shared/tableFooter";
 import { type NetworkEntity } from "~/types/local/network";
+import { useNetworkMembersSocket } from "~/hooks/useNetworkMembersSocket";
 import { useMemberColumns } from "./useMemberColumns";
 import { useTablePersistence } from "./hooks/useTablePersistence";
 import { MembersToolbar } from "./components/MembersToolbar";
@@ -40,6 +41,8 @@ const SERVER_SORTABLE = new Set(["id", "name", "authorized", "physicalAddress"])
 
 export const NetworkMembersTable = ({ nwid, central = false, organizationId }: IProp) => {
 	const { query } = useRouter();
+	// Live updates: server pushes a "changed" event over Socket.IO and we refetch.
+	useNetworkMembersSocket(nwid, central);
 	const [globalFilter, setGlobalFilter] = useState("");
 	const {
 		sorting,
@@ -77,7 +80,9 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 			sortBy: sortBy as any,
 			sortDir,
 		},
-		{ enabled: !!query.id, refetchInterval: 10000 },
+		// Socket.IO drives live updates; this slow poll is just a safety net for a
+		// dropped socket.
+		{ enabled: !!query.id, refetchInterval: 60000 },
 	);
 
 	const totalCount = membersData?.totalCount ?? 0;

--- a/src/components/networkByIdPage/table/members/useMemberColumns.tsx
+++ b/src/components/networkByIdPage/table/members/useMemberColumns.tsx
@@ -7,11 +7,7 @@ import {
 	useTrpcApiSuccessHandler,
 } from "~/hooks/useTrpcApiHandler";
 import { type NetworkMemberNotation, type MemberEntity } from "~/types/local/member";
-import {
-	sortingIpAddress,
-	sortingMemberHex,
-	sortingPhysicalIpAddress,
-} from "~/utils/sorting";
+import { sortingMemberHex, sortingPhysicalIpAddress } from "~/utils/sorting";
 import { COLUMN_SIZING } from "./constants";
 import { AuthorizedCell } from "./cells/AuthorizedCell";
 import { EditableNameCell } from "./cells/EditableNameCell";
@@ -61,12 +57,14 @@ export const useMemberColumns = ({
 	const { mutate: stashUser } = api.networkMember.stash.useMutation({
 		onSuccess: async () => {
 			await utils.network.getNetworkById.invalidate({ nwid, central });
+			await utils.network.getNetworkMembers.invalidate();
 			refetchNetworkById();
 		},
 	});
 	const { mutate: deleteMember } = api.networkMember.delete.useMutation({
 		onSuccess: async () => {
 			await utils.network.getNetworkById.invalidate({ nwid, central });
+			await utils.network.getNetworkMembers.invalidate();
 			refetchNetworkById();
 		},
 	});
@@ -74,6 +72,7 @@ export const useMemberColumns = ({
 		onError: handleApiError,
 		onSuccess: async () => {
 			await utils.network.getNetworkById.invalidate({ nwid, central });
+			await utils.network.getNetworkMembers.invalidate();
 			handleApiSuccess({ actions: [refetchNetworkById] })();
 		},
 	});
@@ -142,6 +141,7 @@ export const useMemberColumns = ({
 				id: "description",
 				...COLUMN_SIZING.description,
 				...leftAligned,
+				enableSorting: false,
 				cell: (ctx) => (
 					<EditableDescriptionCell
 						ctx={ctx}
@@ -162,7 +162,7 @@ export const useMemberColumns = ({
 				id: "ipAssignments",
 				...COLUMN_SIZING.ipAssignments,
 				...leftAligned,
-				sortingFn: sortingIpAddress,
+				enableSorting: false,
 				cell: ({ row: { original }, table }) => (
 					<IpAssignmentsCell
 						original={original}
@@ -187,6 +187,7 @@ export const useMemberColumns = ({
 				header: () => <span>{c("header.conStatus.header")}</span>,
 				id: "conStatus",
 				...COLUMN_SIZING.conStatus,
+				enableSorting: false,
 				cell: ({ row: { original } }) => (
 					<ConnectionStatusCell original={original} central={central} />
 				),

--- a/src/components/shared/tableFooter.tsx
+++ b/src/components/shared/tableFooter.tsx
@@ -5,14 +5,24 @@ import { getLocalStorageItem, setLocalStorageItem } from "~/utils/localstorage";
 
 const MIN_COUNT_TO_SHOW_FOOTER = 11;
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
-const TableFooter = ({ table, page }: { table: Table<any>; page: string }) => {
+const TableFooter = ({
+	table,
+	page,
+	totalCount,
+}: {
+	// biome-ignore lint/suspicious/noExplicitAny: generic table
+	table: Table<any>;
+	page: string;
+	// Server-side tables pass the total row count here; client-side tables omit
+	// it and fall back to the (fully-loaded) data length.
+	totalCount?: number;
+}) => {
 	const t = useTranslations("commonTable");
 	const [pageSize, setPageSize] = useState<string | number>(
 		table.getState().pagination.pageSize,
 	);
 
-	const totalMembersCount = table?.options?.data?.length || 0;
+	const totalMembersCount = totalCount ?? table?.options?.data?.length ?? 0;
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
 	useEffect(() => {

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -170,7 +170,9 @@ export const updatePeers = async () => {
 		// updates every 5 minutes
 
 		// "*/10 * * * * *", // every 10 seconds ( testing )
-		"*/5 * * * *", // every 5min
+		// Backstop only: viewed networks are synced every ~10s by the SyncManager
+		// (Socket.IO subscription-driven). Idle networks reconcile every 10 min here.
+		"*/10 * * * *", // every 10min
 		async () => {
 			try {
 				// fetch all users

--- a/src/cronTasks.ts
+++ b/src/cronTasks.ts
@@ -2,7 +2,7 @@ import * as cron from "cron";
 import { prisma } from "./server/db";
 import * as ztController from "~/utils/ztApi";
 
-import { syncMemberPeersAndStatus } from "./server/api/services/memberService";
+import { reconcileNetworkMembers } from "./server/api/services/memberService";
 
 type FakeContext = {
 	session: {
@@ -238,19 +238,14 @@ export const updatePeers = async () => {
 								},
 							};
 
-							// get members from the zt controller
-							const ztControllerResponse = await ztController.local_network_and_members(
-								// @ts-expect-error
+							// Reconcile members against the controller (revision-delta +
+							// self-healing). Replaces the old per-member N+1 fetch + write storm,
+							// and serves as the periodic backstop that keeps idle networks' caches
+							// converged with the controller.
+							await reconcileNetworkMembers(
+								// @ts-expect-error fake context for the cron
 								context,
 								network.nwid,
-							);
-							if (!ztControllerResponse || !("members" in ztControllerResponse)) return;
-
-							await syncMemberPeersAndStatus(
-								// @ts-expect-error
-								context,
-								network?.nwid,
-								ztControllerResponse.members,
 							);
 						}
 					}

--- a/src/hooks/useNetworkMembersSocket.tsx
+++ b/src/hooks/useNetworkMembersSocket.tsx
@@ -1,0 +1,51 @@
+import { useEffect } from "react";
+import { io } from "socket.io-client";
+import { api } from "~/utils/api";
+import { networkMembersChannel } from "~/utils/socketChannels";
+
+/**
+ * Subscribes to live member updates for a network over Socket.IO. While mounted,
+ * the server reconciles this network every ~10s and pushes a "changed" event when
+ * something actually changed; we then refetch the (DB-first) member list. On
+ * unmount we unsubscribe so the server can stop the loop when no one is viewing.
+ *
+ * Uses a dedicated (forceNew) socket so it never interferes with the org-chat
+ * socket. Central networks are not handled by the local sync worker.
+ */
+export const useNetworkMembersSocket = (nwid: string, central = false) => {
+	const utils = api.useUtils();
+
+	useEffect(() => {
+		if (!nwid || central) return;
+
+		let cancelled = false;
+		let socket: ReturnType<typeof io> | null = null;
+		const channel = networkMembersChannel(nwid);
+
+		(async () => {
+			// Ensure the Socket.IO server is initialized, then connect.
+			await fetch("/api/websocket");
+			if (cancelled) return;
+
+			socket = io({ forceNew: true });
+			const subscribe = () => socket?.emit("subscribe:network", { nwid });
+			// (re)subscribe on every (re)connect.
+			socket.on("connect", subscribe);
+			socket.on(channel, () => {
+				void utils.network.getNetworkMembers.invalidate();
+				void utils.network.getNetworkById.invalidate();
+			});
+		})();
+
+		return () => {
+			cancelled = true;
+			if (socket) {
+				socket.emit("unsubscribe:network", { nwid });
+				socket.off(channel);
+				socket.disconnect();
+			}
+		};
+	}, [nwid, central, utils]);
+};
+
+export default useNetworkMembersSocket;

--- a/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
+++ b/src/pages/api/__tests__/v1/networkMembers/updateMember.test.ts
@@ -132,6 +132,25 @@ describe("Update Network Members", () => {
 
 		// Assertions
 		expect(res.status).toHaveBeenCalledWith(200);
+		// `authorized` must write through to the DB cache (not only the controller),
+		// so the DB-first member list reflects it immediately.
+		expect(prisma.network.update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				data: expect.objectContaining({
+					networkMembers: expect.objectContaining({
+						update: expect.objectContaining({
+							data: expect.objectContaining({ authorized: true }),
+						}),
+					}),
+				}),
+			}),
+		);
+		// and still pushed to the controller.
+		expect(ztController.member_update).toHaveBeenCalledWith(
+			expect.objectContaining({
+				updateParams: expect.objectContaining({ authorized: true }),
+			}),
+		);
 	});
 
 	it("should persist name to the database and controller (issue #929)", async () => {

--- a/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/network/[id]/member/[memberId]/index.ts
@@ -69,7 +69,9 @@ const POST_updateNetworkMember = SecuredPrivateApiRoute(
 		const updateableFields = {
 			name: { type: "string", destinations: ["database", "controller"] },
 			description: { type: "string", destinations: ["database"] },
-			authorized: { type: "boolean", destinations: ["controller"] },
+			// Write-through to the DB cache so the DB-first member list reflects the
+			// change immediately (reconcile is only the eventual backstop).
+			authorized: { type: "boolean", destinations: ["database", "controller"] },
 		};
 
 		if (Object.keys(body).length === 0) {

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/[memberId]/index.ts
@@ -65,13 +65,17 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 			const validatedBody = PostBodySchema.parse(body);
 			// structure of the updateableFields object:
 
+			// Fields that are cached in the DB (authorized/ipAssignments/flags) are
+			// routed to BOTH so the controller change is mirrored into the DB cache
+			// immediately; capabilities/tags/ssoExempt have no DB column and stay
+			// controller-only (reconcile keeps the cache columns honest regardless).
 			const updateableFields = {
 				name: { type: "string", destinations: ["database", "controller"] },
-				authorized: { type: "boolean", destinations: ["controller"] },
-				activeBridge: { type: "boolean", destinations: ["controller"] },
+				authorized: { type: "boolean", destinations: ["database", "controller"] },
+				activeBridge: { type: "boolean", destinations: ["database", "controller"] },
 				capabilities: { type: "array", destinations: ["controller"] },
-				ipAssignments: { type: "array", destinations: ["controller"] },
-				noAutoAssignIps: { type: "boolean", destinations: ["controller"] },
+				ipAssignments: { type: "array", destinations: ["database", "controller"] },
+				noAutoAssignIps: { type: "boolean", destinations: ["database", "controller"] },
 				ssoExempt: { type: "boolean", destinations: ["controller"] },
 				tags: { type: "array", destinations: ["controller"] },
 			};
@@ -191,7 +195,9 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 					});
 				}
 			} else {
-				// Member doesn't exist in DB, create it
+				// Member doesn't exist in DB, create it — seed the cached config fields
+				// (authorized/ipAssignments/flags) from the request so the DB-first list
+				// is correct immediately, not only after the next reconcile.
 				await ctx.prisma.network_members.create({
 					data: {
 						id: memberId,
@@ -199,6 +205,10 @@ export const POST_orgUpdateNetworkMember = SecuredOrganizationApiRoute(
 						lastSeen: new Date(),
 						creationTime: new Date(),
 						name: (databasePayload.name as string) || null,
+						authorized: databasePayload.authorized,
+						ipAssignments: databasePayload.ipAssignments,
+						noAutoAssignIps: databasePayload.noAutoAssignIps,
+						activeBridge: databasePayload.activeBridge,
 						nwid_ref: { connect: { nwid: networkId } },
 					},
 				});

--- a/src/pages/api/v1/org/[orgid]/network/[nwid]/member/index.ts
+++ b/src/pages/api/v1/org/[orgid]/network/[nwid]/member/index.ts
@@ -57,7 +57,13 @@ export const GET_orgNetworkMembers = SecuredOrganizationApiRoute(
 				return res.status(401).json({ error: "Network not found or access denied." });
 			}
 
-			return res.status(200).json(response?.members);
+			// Members are served by the dedicated (DB-first) endpoint; request all.
+			const membersResult = await caller.network.getNetworkMembers({
+				nwid: networkId,
+				pageSize: 100000,
+			});
+
+			return res.status(200).json(membersResult.members);
 		} catch (cause) {
 			return handleApiErrors(cause, res);
 		}

--- a/src/pages/api/websocket/index.ts
+++ b/src/pages/api/websocket/index.ts
@@ -34,19 +34,20 @@ const SocketHandler = async (req: NextApiRequest, res: NextApiResponseWithSocket
 		});
 		res.socket.server.io = io;
 
-		// Attach the user from the session cookie (best-effort). We do NOT reject the
-		// connection on failure — that would also break the existing org-chat socket.
-		// Access is enforced per-network at subscribe time instead.
+		// Require a valid session for EVERY socket: reject unauthenticated
+		// connections outright (no unauthenticated client may hold a socket at all),
+		// then enforce per-network access again at subscribe time (defense in depth).
 		io.use(async (socket, next) => {
 			try {
 				const s = await auth.api.getSession({
 					headers: fromNodeHeaders(socket.handshake.headers),
 				});
-				if (s) socket.data.userId = s.user.id;
+				if (!s) return next(new Error("unauthorized"));
+				socket.data.userId = s.user.id;
+				next();
 			} catch {
-				// ignore — connection still allowed, subscribe will enforce access
+				next(new Error("unauthorized"));
 			}
-			next();
 		});
 
 		// Subscription-driven live member sync: while a client is viewing a network,

--- a/src/pages/api/websocket/index.ts
+++ b/src/pages/api/websocket/index.ts
@@ -1,7 +1,12 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Server } from "socket.io";
+import { Role } from "@prisma/client";
 import { auth } from "~/lib/auth";
 import { fromNodeHeaders } from "better-auth/node";
+import { prisma } from "~/server/db";
+import { checkNetworkAccess } from "~/utils/networkAccess";
+import { syncManager, networkRoom } from "~/server/sync/syncManager";
+import type { UserContext } from "~/types/ctx";
 
 interface SocketIoExtension {
 	socket: {
@@ -29,11 +34,54 @@ const SocketHandler = async (req: NextApiRequest, res: NextApiResponseWithSocket
 		});
 		res.socket.server.io = io;
 
-		// io.on("connection", (socket) => {
-		// 	socket.on("join", ({ roomId }) => {
-		// 		socket.join(roomId);
-		// 	});
-		// });
+		// Attach the user from the session cookie (best-effort). We do NOT reject the
+		// connection on failure — that would also break the existing org-chat socket.
+		// Access is enforced per-network at subscribe time instead.
+		io.use(async (socket, next) => {
+			try {
+				const s = await auth.api.getSession({
+					headers: fromNodeHeaders(socket.handshake.headers),
+				});
+				if (s) socket.data.userId = s.user.id;
+			} catch {
+				// ignore — connection still allowed, subscribe will enforce access
+			}
+			next();
+		});
+
+		// Subscription-driven live member sync: while a client is viewing a network,
+		// the SyncManager reconciles it every ~10s and pushes a "changed" event.
+		io.on("connection", (socket) => {
+			const subscribed = new Set<string>();
+			const userId = socket.data.userId as string | undefined;
+			const ctx = {
+				session: { user: { id: userId } },
+				prisma,
+			} as unknown as UserContext;
+
+			socket.on("subscribe:network", async ({ nwid }: { nwid?: string }) => {
+				if (!nwid || subscribed.has(nwid) || !userId) return;
+				try {
+					await checkNetworkAccess(ctx, nwid, Role.READ_ONLY);
+				} catch {
+					return; // no access → ignore silently
+				}
+				subscribed.add(nwid);
+				socket.join(networkRoom(nwid));
+				syncManager.acquire(io, ctx, nwid);
+			});
+
+			socket.on("unsubscribe:network", ({ nwid }: { nwid?: string }) => {
+				if (!nwid || !subscribed.delete(nwid)) return;
+				socket.leave(networkRoom(nwid));
+				syncManager.release(nwid);
+			});
+
+			socket.on("disconnect", () => {
+				for (const nwid of subscribed) syncManager.release(nwid);
+				subscribed.clear();
+			});
+		});
 	}
 	res.end();
 };

--- a/src/pages/central/[id].tsx
+++ b/src/pages/central/[id].tsx
@@ -73,7 +73,7 @@ const CentralNetworkById = ({ orgIds }) => {
 		);
 	}
 
-	const { network, members = [] } = networkById || {};
+	const { network, memberCount = 0 } = networkById || {};
 
 	if (errorNetwork) {
 		return (
@@ -201,7 +201,7 @@ const CentralNetworkById = ({ orgIds }) => {
 				{t("networkById.networkMembers")}
 			</div>
 			<div className="mx-auto w-full px-4 py-4 text-sm sm:px-10 md:text-base">
-				{members?.length ? (
+				{memberCount ? (
 					<div className="membersTable-wrapper">
 						<NetworkMembersTable nwid={network.id} central={true} />
 					</div>

--- a/src/pages/network/[id].tsx
+++ b/src/pages/network/[id].tsx
@@ -70,7 +70,7 @@ const NetworkById = ({ orgIds }: IProps) => {
 		},
 		{ enabled: !!query.id, refetchInterval: 10000 },
 	);
-	const { network, members = [] } = networkById || {};
+	const { network, memberCount = 0 } = networkById || {};
 	const pageTitle = `${globalOptions?.siteName} - ${network?.name}`;
 	if (errorNetwork) {
 		return (
@@ -232,7 +232,7 @@ const NetworkById = ({ orgIds }: IProps) => {
 				{t("networkById.networkMembers")}
 			</div>
 			<div className="mx-auto w-full px-4 py-4 text-sm sm:px-10 md:text-base">
-				{members.length ? (
+				{memberCount ? (
 					<div className="membersTable-wrapper">
 						<NetworkMembersTable nwid={network.nwid} central={false} />
 					</div>

--- a/src/pages/organization/[orgid]/[id].tsx
+++ b/src/pages/organization/[orgid]/[id].tsx
@@ -58,7 +58,7 @@ const OrganizationNetworkById = ({ orgIds }: IProps) => {
 		},
 		{ enabled: !!query.id, refetchInterval: 10000 },
 	);
-	const { network, members = [] } = networkById || {};
+	const { network, memberCount = 0 } = networkById || {};
 	const pageTitle = `${globalOptions?.siteName} - ${network?.name}`;
 
 	if (errorNetwork) {
@@ -226,7 +226,7 @@ const OrganizationNetworkById = ({ orgIds }: IProps) => {
 				{t("networkById.networkMembers")}
 			</div>
 			<div className="w-5/5 mx-auto w-full  py-4 text-sm md:text-base">
-				{members.length ? (
+				{memberCount ? (
 					<div className="membersTable-wrapper">
 						<NetworkMembersTable
 							nwid={network.nwid}

--- a/src/server/api/__tests__/network/getNetworkMembers.test.ts
+++ b/src/server/api/__tests__/network/getNetworkMembers.test.ts
@@ -1,0 +1,116 @@
+// Use the global `jest` so ts-jest hoists these module mocks above the imports.
+jest.mock("~/server/api/services/memberService", () => ({
+	reconcileNetworkMembersOnce: jest.fn().mockResolvedValue([]),
+	triggerBackgroundReconcile: jest.fn(),
+	// passthrough — return the DB rows unchanged so we can assert pagination
+	attachLiveStatus: jest.fn((_ctx: unknown, rows: unknown) => Promise.resolve(rows)),
+}));
+jest.mock("~/utils/ztApi", () => ({
+	central_network_and_members: jest.fn(),
+}));
+
+import { appRouter } from "../../root";
+import * as memberService from "~/server/api/services/memberService";
+import * as ztController from "~/utils/ztApi";
+import type { Session } from "~/lib/authTypes";
+
+// biome-ignore lint/suspicious/noExplicitAny: test helpers
+const svc = memberService as any;
+// biome-ignore lint/suspicious/noExplicitAny: test helpers
+const zt = ztController as any;
+
+const session = {
+	expires: "",
+	user: { id: "userid", name: "n", email: "e@e.com" },
+} as unknown as Session;
+
+const makeCtx = (over: Record<string, unknown> = {}) => {
+	const prisma = {
+		network: {
+			findUnique: jest
+				.fn()
+				.mockResolvedValue({ authorId: "userid", organizationId: null }),
+		},
+		userOrganizationRole: { findFirst: jest.fn() },
+		network_members: {
+			count: jest.fn(),
+			findMany: jest.fn().mockResolvedValue([]),
+		},
+		...over,
+	};
+	// biome-ignore lint/suspicious/noExplicitAny: minimal trpc ctx
+	return { session, prisma, wss: null, res: null } as any;
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("network.getNetworkMembers", () => {
+	test("serves a DB page (warm cache) and triggers a background reconcile", async () => {
+		const rows = [{ id: "aaa" }, { id: "bbb" }];
+		const ctx = makeCtx();
+		ctx.prisma.network_members.count
+			.mockResolvedValueOnce(5) // cachedCount → warm
+			.mockResolvedValueOnce(5) // totalCount
+			.mockResolvedValueOnce(3); // authorizedCount
+		ctx.prisma.network_members.findMany.mockResolvedValue(rows);
+
+		const caller = appRouter.createCaller(ctx);
+		const result = await caller.network.getNetworkMembers({
+			nwid: "nw1",
+			page: 2,
+			pageSize: 10,
+			sortBy: "name",
+			sortDir: "desc",
+		});
+
+		expect(result).toEqual({ members: rows, totalCount: 5, authorizedCount: 3 });
+		// Warm cache → background reconcile, never a blocking one.
+		expect(svc.triggerBackgroundReconcile).toHaveBeenCalledWith(ctx, "nw1");
+		expect(svc.reconcileNetworkMembersOnce).not.toHaveBeenCalled();
+		// Pagination + sort translated to SQL.
+		const args = ctx.prisma.network_members.findMany.mock.calls[0][0];
+		expect(args.skip).toBe(20);
+		expect(args.take).toBe(10);
+		expect(args.orderBy).toEqual({ name: "desc" });
+		expect(args.where).toMatchObject({ nwid: "nw1", deleted: false });
+	});
+
+	test("cold cache reconciles synchronously before serving", async () => {
+		const ctx = makeCtx();
+		ctx.prisma.network_members.count
+			.mockResolvedValueOnce(0) // cachedCount → cold
+			.mockResolvedValueOnce(0)
+			.mockResolvedValueOnce(0);
+
+		const caller = appRouter.createCaller(ctx);
+		await caller.network.getNetworkMembers({ nwid: "nw1" });
+
+		expect(svc.reconcileNetworkMembersOnce).toHaveBeenCalledWith(ctx, "nw1");
+		expect(svc.triggerBackgroundReconcile).not.toHaveBeenCalled();
+	});
+
+	test("central networks paginate the hosted member list in memory", async () => {
+		const ctx = makeCtx();
+		zt.central_network_and_members.mockResolvedValue({
+			members: [
+				{ id: "a", authorized: true },
+				{ id: "b", authorized: false },
+				{ id: "c", authorized: true },
+			],
+		});
+
+		const caller = appRouter.createCaller(ctx);
+		const result = await caller.network.getNetworkMembers({
+			nwid: "nw1",
+			central: true,
+			page: 0,
+			pageSize: 2,
+		});
+
+		expect(result.totalCount).toBe(3);
+		expect(result.authorizedCount).toBe(2);
+		expect(result.members).toHaveLength(2);
+		// No DB pagination for central.
+		expect(ctx.prisma.network_members.findMany).not.toHaveBeenCalled();
+	});
+});

--- a/src/server/api/__tests__/services/reconcileNetworkMembers.test.ts
+++ b/src/server/api/__tests__/services/reconcileNetworkMembers.test.ts
@@ -1,0 +1,129 @@
+// NOTE: use the global `jest` (not @jest/globals) so ts-jest hoists `jest.mock`
+// above the imports — otherwise the module mock below would not apply.
+
+// Controller API is namespace-imported by the service, so mock the module.
+jest.mock("~/utils/ztApi", () => ({
+	network_members: jest.fn(),
+	member_details: jest.fn(),
+	peers: jest.fn(),
+}));
+
+import * as ztController from "~/utils/ztApi";
+import { prisma } from "~/server/db";
+import { reconcileNetworkMembers } from "~/server/api/services/memberService";
+
+const nwid = "nw123";
+const ctx = { session: { user: { id: "user1" } } } as never;
+
+// biome-ignore lint/suspicious/noExplicitAny: test helpers
+const ztMock = ztController as any;
+// biome-ignore lint/suspicious/noExplicitAny: the service uses the prisma singleton; reassign its methods
+const dbMock = prisma.network_members as any;
+
+const dbRow = (id: string, over: Record<string, unknown> = {}) => ({
+	id,
+	nwid,
+	address: id,
+	revision: 1,
+	online: false,
+	deleted: false,
+	permanentlyDeleted: false,
+	name: "n",
+	physicalAddress: null,
+	ipAssignments: [],
+	notations: [],
+	...over,
+});
+
+beforeEach(() => {
+	dbMock.findMany = jest.fn();
+	dbMock.updateMany = jest.fn().mockResolvedValue({ count: 1 });
+	dbMock.deleteMany = jest.fn().mockResolvedValue({ count: 1 });
+	// Echo the requested id back as the fetched detail (so it matches an existing
+	// DB row and avoids the new-member create path unless a test opts into it).
+	ztMock.member_details.mockImplementation((_ctx, _nwid, id) =>
+		Promise.resolve(
+			dbRow(id, { authorized: true, ipAssignments: ["10.0.0.2"], name: "" }),
+		),
+	);
+	ztMock.peers.mockResolvedValue([]);
+});
+
+describe("reconcileNetworkMembers — revision-delta sync", () => {
+	test("fetches only new/changed members and deletes controller-orphaned rows", async () => {
+		// Controller: A unchanged(1), B changed(1->2), C unchanged(5). D is gone.
+		ztMock.network_members.mockResolvedValue({ A: 1, B: 2, C: 5 });
+		dbMock.findMany
+			.mockResolvedValueOnce([
+				dbRow("A", { revision: 1 }),
+				dbRow("B", { revision: 1 }),
+				dbRow("C", { revision: 5 }),
+				dbRow("D", { revision: 9 }),
+			])
+			.mockResolvedValueOnce([dbRow("A"), dbRow("B", { revision: 2 }), dbRow("C")]);
+
+		const result = await reconcileNetworkMembers(ctx, nwid);
+
+		// Only B (revision changed) is fetched — not A or C.
+		expect(ztMock.member_details).toHaveBeenCalledTimes(1);
+		expect(ztMock.member_details).toHaveBeenCalledWith(ctx, nwid, "B", false);
+
+		// Orphan D (absent from the controller) is removed from the DB.
+		expect(dbMock.deleteMany).toHaveBeenCalledWith({
+			where: { nwid, id: { in: ["D"] } },
+		});
+
+		expect(result.map((m) => m.id).sort()).toEqual(["A", "B", "C"]);
+	});
+
+	test("fetches nothing when all revisions match (warm cache)", async () => {
+		ztMock.network_members.mockResolvedValue({ A: 1, B: 1 });
+		dbMock.findMany
+			.mockResolvedValueOnce([dbRow("A"), dbRow("B")])
+			.mockResolvedValueOnce([dbRow("A"), dbRow("B")]);
+
+		await reconcileNetworkMembers(ctx, nwid);
+
+		expect(ztMock.member_details).not.toHaveBeenCalled();
+		expect(dbMock.deleteMany).not.toHaveBeenCalled();
+		// No config writes and no status writes (all offline + unchanged).
+		expect(dbMock.updateMany).not.toHaveBeenCalled();
+	});
+
+	test("refetches every member on a full resync", async () => {
+		ztMock.network_members.mockResolvedValue({ A: 1, B: 1 });
+		dbMock.findMany
+			.mockResolvedValueOnce([dbRow("A"), dbRow("B")])
+			.mockResolvedValueOnce([dbRow("A"), dbRow("B")]);
+
+		await reconcileNetworkMembers(ctx, nwid, { full: true });
+
+		expect(ztMock.member_details).toHaveBeenCalledTimes(2);
+	});
+
+	test("writes status only for members whose online state changed", async () => {
+		ztMock.network_members.mockResolvedValue({ A: 1, B: 1 });
+		dbMock.findMany
+			.mockResolvedValueOnce([dbRow("A"), dbRow("B")])
+			.mockResolvedValueOnce([
+				dbRow("A", { online: false }),
+				dbRow("B", { online: false }),
+			]);
+		// A has a live peer (becomes online); B has none (stays offline).
+		ztMock.peers.mockResolvedValue([
+			{
+				address: "A",
+				latency: 10,
+				paths: [{ address: "10.0.0.1/9993", active: true, preferred: true }],
+			},
+		]);
+
+		await reconcileNetworkMembers(ctx, nwid);
+
+		// Exactly one status write — for A (online flipped). B is skipped.
+		expect(dbMock.updateMany).toHaveBeenCalledTimes(1);
+		const call = dbMock.updateMany.mock.calls[0][0];
+		expect(call.where).toEqual({ nwid, id: "A" });
+		expect(call.data.online).toBe(true);
+	});
+});

--- a/src/server/api/__tests__/sync/syncManager.test.ts
+++ b/src/server/api/__tests__/sync/syncManager.test.ts
@@ -1,0 +1,105 @@
+// Global `jest` so ts-jest hoists this mock above the import.
+jest.mock("~/server/api/services/memberService", () => ({
+	reconcileNetworkMembersOnce: jest.fn(),
+}));
+
+import { reconcileNetworkMembersOnce } from "~/server/api/services/memberService";
+import { syncManager, networkRoom, SYNC_INTERVAL_MS } from "~/server/sync/syncManager";
+
+// biome-ignore lint/suspicious/noExplicitAny: test helper
+const recon = reconcileNetworkMembersOnce as any;
+const ctx = {} as never;
+
+const makeIo = () => {
+	const emit = jest.fn();
+	const to = jest.fn(() => ({ emit }));
+	return { io: { to } as never, to, emit };
+};
+
+// biome-ignore lint/suspicious/noExplicitAny: minimal member fixture
+const member = (over: Record<string, unknown> = {}): any => ({
+	id: "a",
+	authorized: true,
+	conStatus: 2,
+	ipAssignments: ["10.0.0.1"],
+	name: "n",
+	...over,
+});
+
+beforeEach(() => {
+	jest.useFakeTimers();
+	recon.mockReset();
+});
+afterEach(() => {
+	jest.useRealTimers();
+});
+
+describe("SyncManager", () => {
+	test("ref-counts viewers and stops the loop when the last leaves", async () => {
+		recon.mockResolvedValue([member()]);
+		const { io } = makeIo();
+
+		syncManager.acquire(io, ctx, "nw_ref");
+		expect(syncManager.isSyncing("nw_ref")).toBe(true);
+		expect(syncManager.refCount("nw_ref")).toBe(1);
+
+		syncManager.acquire(io, ctx, "nw_ref"); // second viewer — no new loop
+		expect(syncManager.refCount("nw_ref")).toBe(2);
+
+		syncManager.release("nw_ref");
+		expect(syncManager.isSyncing("nw_ref")).toBe(true); // still one viewer
+
+		syncManager.release("nw_ref");
+		expect(syncManager.isSyncing("nw_ref")).toBe(false); // loop stopped
+
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS * 2); // no further ticks
+	});
+
+	test("never overlaps: a slow reconcile blocks the next tick until it finishes", async () => {
+		let resolveRecon: (v: unknown) => void = () => {};
+		recon.mockReturnValue(
+			new Promise((r) => {
+				resolveRecon = r;
+			}),
+		);
+		const { io } = makeIo();
+
+		syncManager.acquire(io, ctx, "nw_slow");
+		expect(recon).toHaveBeenCalledTimes(1);
+
+		// Even well past the interval, the still-running reconcile is not re-run.
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS * 3);
+		expect(recon).toHaveBeenCalledTimes(1);
+
+		// Once it completes, the next tick is scheduled.
+		recon.mockResolvedValue([member()]);
+		resolveRecon([member()]);
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS + 5);
+		expect(recon.mock.calls.length).toBeGreaterThanOrEqual(2);
+
+		syncManager.release("nw_slow");
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS * 2);
+	});
+
+	test("emits to the network room only when the member state changes", async () => {
+		recon.mockResolvedValue([member({ conStatus: 2 })]);
+		const { io, to, emit } = makeIo();
+
+		syncManager.acquire(io, ctx, "nw_emit");
+		await jest.advanceTimersByTimeAsync(1); // let the first tick settle
+		expect(to).toHaveBeenCalledWith(networkRoom("nw_emit"));
+		expect(emit).toHaveBeenCalledTimes(1); // first sync → changed from empty
+
+		// Same data next tick → no emit.
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS);
+		expect(emit).toHaveBeenCalledTimes(1);
+
+		// Status flips → emit again.
+		recon.mockResolvedValue([member({ conStatus: 0 })]);
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS);
+		expect(emit).toHaveBeenCalledTimes(2);
+
+		syncManager.release("nw_emit");
+		await jest.advanceTimersByTimeAsync(SYNC_INTERVAL_MS * 2);
+	});
+});

--- a/src/server/api/routers/memberRouter.ts
+++ b/src/server/api/routers/memberRouter.ts
@@ -560,6 +560,17 @@ export const networkMemberRouter = createTRPCRouter({
 					if (updateParams.description !== undefined) {
 						databaseUpdateData.description = updateParams.description;
 					}
+					// Write-through the cached controller config so the DB-first member
+					// list reflects the change immediately (before the next reconcile).
+					if (payload.ipAssignments !== undefined) {
+						databaseUpdateData.ipAssignments = payload.ipAssignments;
+					}
+					if (payload.noAutoAssignIps !== undefined) {
+						databaseUpdateData.noAutoAssignIps = payload.noAutoAssignIps;
+					}
+					if (payload.activeBridge !== undefined) {
+						databaseUpdateData.activeBridge = payload.activeBridge;
+					}
 
 					// Update database if there are fields to update
 					if (Object.keys(databaseUpdateData).length > 0) {

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -16,7 +16,11 @@ import {
 	type NetworkDeleted,
 } from "~/types/webhooks";
 import { sendWebhook } from "~/utils/webhook";
-import { fetchZombieMembers, syncMemberPeersAndStatus } from "../services/memberService";
+import {
+	attachLiveStatus,
+	reconcileNetworkMembersOnce,
+	triggerBackgroundReconcile,
+} from "../services/memberService";
 import { isValidCIDR, isValidDns, isValidIP } from "../utils/ipUtils";
 import { networkProvisioningFactory } from "../services/networkService";
 import { Address4, Address6 } from "ip-address";
@@ -120,11 +124,20 @@ export const networkRouter = createTRPCRouter({
 		)
 		.query(async ({ ctx, input }) => {
 			if (input.central) {
-				return await ztController.central_network_and_members(
+				// Keep getNetworkById's shape uniform: meta + counts (members are served
+				// by getNetworkMembers). Central has no DB-backed zombie members.
+				const centralResponse = await ztController.central_network_and_members(
 					ctx,
 					input.nwid,
 					input.central,
 				);
+				const centralMembers = (centralResponse?.members ?? []) as MemberEntity[];
+				return {
+					network: centralResponse?.network,
+					memberCount: centralMembers.length,
+					authorizedMemberCount: centralMembers.filter((m) => m.authorized).length,
+					zombieMembers: [] as network_members[],
+				};
 			}
 
 			try {
@@ -161,98 +174,46 @@ export const networkRouter = createTRPCRouter({
 				}
 
 				/**
-				 * Response from the ztController.local_network_and_members method.
-				 * @type {Promise<any>}
+				 * Network details from the controller (metadata + routes only — members
+				 * are reconciled separately to avoid an N+1 per-member fetch).
 				 */
-				const ztControllerResponse = await ztController
-					.local_network_and_members(ctx, networkFromDatabase.nwid)
+				const controllerNetwork = await ztController
+					.get_network(ctx, networkFromDatabase.nwid)
 					.catch((err: APIError) => {
 						throwError(`${err.message}`);
 					});
 
-				if (!ztControllerResponse) return throwError("Failed to get network details!");
+				if (!controllerNetwork) return throwError("Failed to get network details!");
 
-				/**
-				 * Syncs member peers and status.
-				 */
-				const membersWithStatusAndPeers = await syncMemberPeersAndStatus(
-					ctx,
-					input.nwid,
-					ztControllerResponse.members,
-				).catch((err) => {
-					console.error("Error syncing member peers and status:", err);
-					// Return empty array on sync error to prevent complete failure
-					return [];
+				// Members are served (paginated) by getNetworkMembers. Here we just kick
+				// off a deduped reconcile — awaiting it only on a cold cache so the page's
+				// counts aren't empty on first load — then derive lightweight counts and
+				// the stashed (zombie) list straight from the DB.
+				const cachedCount = await ctx.prisma.network_members.count({
+					where: { nwid: input.nwid },
 				});
+				if (cachedCount === 0) {
+					await reconcileNetworkMembersOnce(ctx, input.nwid).catch((err) => {
+						console.error("Initial reconcile failed:", err);
+					});
+				} else {
+					triggerBackgroundReconcile(ctx, input.nwid);
+				}
 
 				// Generate CIDR options for IP configuration
 				const { cidrOptions } = IPv4gen(null, []);
 
-				/**
-				 * Merging logic to ensure proper member visibility:
-				 * 1. Start with database members (both active and stashed)
-				 * 2. Only add controller members if they don't exist in database
-				 * 3. Filter out stashed members from final result
-				 */
-				const mergedMembersMap = new Map();
-
-				// First, fetch ALL members from database (including deleted/stashed ones)
-				const allDatabaseMembers = await ctx.prisma.network_members.findMany({
-					where: {
-						nwid: input.nwid,
-					},
-				});
-
-				/**
-				 * Get stashed/zombie members directly from database.
-				 * These are members that were previously stashed (deleted: true) but not permanently deleted
-				 */
-				const zombieMembers = allDatabaseMembers.filter(
-					(member) => member.deleted && !member.permanentlyDeleted,
-				);
-
-				// Add all database members to the map (this gives us the authoritative record)
-				for (const member of allDatabaseMembers) {
-					// For database members, merge with controller data if available
-					const controllerMember = membersWithStatusAndPeers.find(
-						(m) => m.id === member.id,
-					);
-					if (controllerMember && !member.deleted) {
-						// Merge database and controller data for active members
-						mergedMembersMap.set(member.id, {
-							...controllerMember,
-							...member, // Database data takes precedence
-						});
-					} else if (!member.deleted) {
-						// Database-only member (manually added), not stashed
-						mergedMembersMap.set(member.id, member);
-					}
-					// Note: Stashed members (deleted: true) are deliberately not added to the map
-				}
-
-				// Pre-fetch permanently deleted members to avoid N+1 queries in the loop
-				const permanentlyDeletedMemberIds = new Set(
-					(
-						await ctx.prisma.network_members.findMany({
-							where: {
-								nwid: input.nwid,
-								permanentlyDeleted: true,
-							},
-							select: { id: true },
-						})
-					).map((member) => member.id),
-				);
-
-				// Then, add controller members that don't exist in database at all
-				// BUT exclude members that were permanently deleted
-				for (const member of membersWithStatusAndPeers) {
-					if (!allDatabaseMembers.some((dbMember) => dbMember.id === member.id)) {
-						// Only add as new member if it was never permanently deleted
-						if (!permanentlyDeletedMemberIds.has(member.id)) {
-							mergedMembersMap.set(member.id, member);
-						}
-					}
-				}
+				const [zombieMembers, memberCount, authorizedMemberCount] = await Promise.all([
+					ctx.prisma.network_members.findMany({
+						where: { nwid: input.nwid, deleted: true, permanentlyDeleted: false },
+					}),
+					ctx.prisma.network_members.count({
+						where: { nwid: input.nwid, deleted: false },
+					}),
+					ctx.prisma.network_members.count({
+						where: { nwid: input.nwid, deleted: false, authorized: true },
+					}),
+				]);
 
 				// if the networkFromDatabase.routes is not equal to the ztControllerResponse.routes, update the networkFromDatabase.routes
 				// Only sync if routes actually differ to avoid unnecessary database operations
@@ -260,9 +221,7 @@ export const networkRouter = createTRPCRouter({
 					networkFromDatabase.routes?.map((r) => `${r.target}|${r.via || "null"}`) || [],
 				);
 				const ztRouteKeys = new Set(
-					ztControllerResponse.network.routes?.map(
-						(r) => `${r.target}|${r.via || "null"}`,
-					) || [],
+					controllerNetwork.routes?.map((r) => `${r.target}|${r.via || "null"}`) || [],
 				);
 				const routesAreDifferent =
 					dbRouteKeys.size !== ztRouteKeys.size ||
@@ -272,14 +231,12 @@ export const networkRouter = createTRPCRouter({
 					await syncNetworkRoutes({
 						networkId: input.nwid,
 						networkFromDatabase,
-						ztControllerRoutes: ztControllerResponse.network.routes,
+						ztControllerRoutes: controllerNetwork.routes,
 					});
 				}
 
 				// check if there is other network using same routes and return a notification
-				const targetIPs = ztControllerResponse.network.routes.map(
-					(route) => route.target,
-				);
+				const targetIPs = controllerNetwork.routes.map((route) => route.target);
 				interface DuplicateRoutes {
 					authorId: string;
 					routes: RoutesEntity[];
@@ -323,13 +280,10 @@ export const networkRouter = createTRPCRouter({
 				// Remove duplicates from the list of duplicated IPs
 				const uniqueDuplicatedIPs = [...new Set(duplicatedIPs)];
 
-				// Convert the map back to an array of merged members
-				const mergedMembers = [...mergedMembersMap.values()];
-
 				// Construct the final response object using the already fetched network data
 				return {
 					network: {
-						...ztControllerResponse?.network,
+						...controllerNetwork,
 						...networkFromDatabase,
 						cidr: cidrOptions,
 						duplicateRoutes: duplicateRoutes.map((network) => ({
@@ -337,7 +291,8 @@ export const networkRouter = createTRPCRouter({
 							duplicatedIPs: uniqueDuplicatedIPs,
 						})),
 					},
-					members: mergedMembers as MemberEntity[],
+					memberCount,
+					authorizedMemberCount,
 					zombieMembers,
 				};
 			} catch (error) {
@@ -345,6 +300,105 @@ export const networkRouter = createTRPCRouter({
 				// Re-throw to maintain API contract
 				throw error;
 			}
+		}),
+	/**
+	 * Paginated, DB-first member list for a network. Serves a page straight from
+	 * the database (fast, scales to thousands of members) enriched with live
+	 * connection status, and triggers a background controller reconcile to keep
+	 * the cache fresh. On a cold cache (no rows yet) it reconciles synchronously
+	 * so the first load isn't empty.
+	 */
+	getNetworkMembers: protectedProcedure
+		.input(
+			z.object({
+				nwid: z.string(),
+				central: z.boolean().optional().default(false),
+				page: z.number().int().min(0).default(0),
+				// High cap so "list all members" callers (REST collection endpoint,
+				// routes name-resolution) can request the full set in one page.
+				pageSize: z.number().int().min(1).max(100000).default(50),
+				search: z.string().trim().optional(),
+				sortBy: z
+					.enum([
+						"id",
+						"name",
+						"authorized",
+						"online",
+						"physicalAddress",
+						"lastSeen",
+						"creationTime",
+					])
+					.default("id"),
+				sortDir: z.enum(["asc", "desc"]).default("asc"),
+			}),
+		)
+		.query(async ({ ctx, input }) => {
+			await checkNetworkAccess(ctx, input.nwid, Role.READ_ONLY);
+
+			// Central networks are hosted by ZeroTier; keep the existing fetch and
+			// paginate in memory (the local-controller N+1 is the issue we target).
+			if (input.central) {
+				const response = await ztController.central_network_and_members(
+					ctx,
+					input.nwid,
+					true,
+				);
+				const all = (response?.members ?? []) as MemberEntity[];
+				const start = input.page * input.pageSize;
+				return {
+					members: all.slice(start, start + input.pageSize),
+					totalCount: all.length,
+					authorizedCount: all.filter((m) => m.authorized).length,
+				};
+			}
+
+			// Cold cache: populate synchronously so the first load isn't empty.
+			// Otherwise serve the DB and refresh in the background.
+			const cachedCount = await ctx.prisma.network_members.count({
+				where: { nwid: input.nwid },
+			});
+			if (cachedCount === 0) {
+				await reconcileNetworkMembersOnce(ctx, input.nwid).catch((err) => {
+					console.error("Initial reconcile failed:", err);
+				});
+			} else {
+				triggerBackgroundReconcile(ctx, input.nwid);
+			}
+
+			const search = input.search;
+			const where = {
+				nwid: input.nwid,
+				deleted: false,
+				...(search
+					? {
+							OR: [
+								{ id: { contains: search, mode: "insensitive" as const } },
+								{ name: { contains: search, mode: "insensitive" as const } },
+								{
+									physicalAddress: { contains: search, mode: "insensitive" as const },
+								},
+								{ ipAssignments: { has: search } },
+							],
+						}
+					: {}),
+			};
+
+			const [rows, totalCount, authorizedCount] = await Promise.all([
+				ctx.prisma.network_members.findMany({
+					where,
+					orderBy: { [input.sortBy]: input.sortDir },
+					skip: input.page * input.pageSize,
+					take: input.pageSize,
+					include: { notations: { include: { label: true } } },
+				}),
+				ctx.prisma.network_members.count({ where }),
+				ctx.prisma.network_members.count({
+					where: { nwid: input.nwid, deleted: false, authorized: true },
+				}),
+			]);
+
+			const members = await attachLiveStatus(ctx, rows);
+			return { members, totalCount, authorizedCount };
 		}),
 	deleteNetwork: protectedProcedure
 		.input(

--- a/src/server/api/services/memberService.ts
+++ b/src/server/api/services/memberService.ts
@@ -376,3 +376,224 @@ export const fetchZombieMembers = async (
 	const zombieMembers = await Promise.all(getZombieMembersPromises);
 	return zombieMembers.filter(Boolean);
 };
+
+const MEMBER_DETAIL_BATCH_SIZE = 5;
+
+/**
+ * Fetches full member detail from the controller for the given ids, in small
+ * batches (the controller has no bulk member endpoint). Failures are skipped.
+ */
+const fetchMemberDetailsBatched = async (
+	ctx: UserContext,
+	nwid: string,
+	ids: string[],
+): Promise<MemberEntity[]> => {
+	const results: MemberEntity[] = [];
+	for (let i = 0; i < ids.length; i += MEMBER_DETAIL_BATCH_SIZE) {
+		const batch = ids.slice(i, i + MEMBER_DETAIL_BATCH_SIZE);
+		const batchResults = await Promise.all(
+			batch.map((id) =>
+				ztController.member_details(ctx, nwid, id, false).catch((err) => {
+					console.error(`reconcileNetworkMembers: failed to fetch member ${id}:`, err);
+					return null;
+				}),
+			),
+		);
+		for (const r of batchResults) if (r) results.push(r as MemberEntity);
+	}
+	return results;
+};
+
+/**
+ * reconcileNetworkMembers
+ *
+ * Controller-truth, self-healing sync built to scale to large networks. The
+ * ZeroTier controller has no bulk member endpoint, so fetching every member's
+ * detail on every load is the bottleneck. Instead this:
+ *   1. reads the cheap `{ memberId: revision }` map (the authoritative membership),
+ *   2. fetches full detail ONLY for new or revision-changed members and caches
+ *      their config (authorized, ipAssignments, flags, revision) in the DB,
+ *   3. removes DB rows for members the controller no longer has (drift cleanup),
+ *   4. computes live status from a single `peers` call (Map lookup, not O(n²)) and
+ *      writes back only the members whose status actually changed.
+ *
+ * Pass `{ full: true }` to ignore cached revisions and refetch every member
+ * (used by the periodic backstop resync).
+ *
+ * Returns the enriched, active members (DB-cached config + live status).
+ */
+export const reconcileNetworkMembers = async (
+	ctx: UserContext,
+	nwid: string,
+	options: { full?: boolean } = {},
+): Promise<MemberEntity[]> => {
+	// 1. Authoritative membership + revisions from the controller (one cheap call).
+	const revisionMap = (await ztController.network_members(ctx, nwid, false)) as Record<
+		string,
+		number
+	>;
+	const controllerIds = Object.keys(revisionMap);
+
+	// 2. Current DB rows for this network.
+	const dbMembers = await prisma.network_members.findMany({
+		where: { nwid },
+		include: { notations: { include: { label: true } } },
+	});
+	const dbMap = new Map(dbMembers.map((m) => [m.id, m]));
+
+	// 3. Which members need a fresh detail fetch? New, revision-changed, or full
+	//    resync. Stashed / permanently-deleted members stay hidden and are skipped.
+	const idsToFetch = controllerIds.filter((id) => {
+		const db = dbMap.get(id);
+		if (db && (db.deleted || db.permanentlyDeleted)) return false;
+		if (!db) return true;
+		if (options.full) return true;
+		return db.revision == null || db.revision !== revisionMap[id];
+	});
+
+	// 4. Fetch changed details (batched) and cache their config in the DB.
+	const details = await fetchMemberDetailsBatched(ctx, nwid, idsToFetch);
+	for (const detail of details) {
+		const db = dbMap.get(detail.id);
+		if (!db) {
+			// New member: create the row (handles naming + join webhooks/notifications).
+			await addNetworkMember(ctx, detail).catch(console.error);
+		}
+		await prisma.network_members.updateMany({
+			where: { nwid, id: detail.id },
+			data: {
+				authorized: !!detail.authorized,
+				ipAssignments: Array.isArray(detail.ipAssignments) ? detail.ipAssignments : [],
+				noAutoAssignIps: !!detail.noAutoAssignIps,
+				activeBridge: !!detail.activeBridge,
+				address: detail.address ?? detail.id,
+				revision: revisionMap[detail.id] ?? null,
+				// Smart name preservation (#719): adopt the controller name only when the
+				// DB has none — never clobber a user-set name.
+				...(!db?.name?.trim() && detail.name?.trim() ? { name: detail.name } : {}),
+			},
+		});
+	}
+
+	// 5. Drift cleanup: active DB members the controller no longer knows about.
+	const controllerIdSet = new Set(controllerIds);
+	const orphanIds = dbMembers
+		.filter((m) => !controllerIdSet.has(m.id) && !m.deleted && !m.permanentlyDeleted)
+		.map((m) => m.id);
+	if (orphanIds.length > 0) {
+		await prisma.network_members.deleteMany({ where: { nwid, id: { in: orphanIds } } });
+	}
+
+	// 6. Live status from a single peers call (Map lookup instead of O(n²) filter).
+	const controllerPeers = await ztController.peers(ctx);
+	const peersByAddress = new Map<string, Peers>();
+	for (const peer of controllerPeers) {
+		peersByAddress.set(peer.address, peer as unknown as Peers);
+	}
+
+	// 7. Build the active member list from the reconciled DB rows + live status,
+	//    writing back only members whose status actually changed.
+	const activeDbMembers = await prisma.network_members.findMany({
+		where: { nwid, id: { in: controllerIds }, deleted: false },
+		include: { notations: { include: { label: true } } },
+	});
+
+	const statusWrites: Promise<unknown>[] = [];
+	const enriched = activeDbMembers.map((db) => {
+		const peers = peersByAddress.get(db.address || "") ?? ({} as Peers);
+		const activePreferredPath = findActivePreferredPeerPath(peers);
+		const member = {
+			...db,
+			peers,
+			physicalAddress: activePreferredPath?.address ?? db.physicalAddress,
+		} as unknown as MemberEntity;
+
+		member.conStatus = determineConnectionStatus(member);
+		const online = Object.keys(peers).length > 0 && member.conStatus !== 0;
+
+		// diff-skip: offline-and-unchanged members are never rewritten.
+		if (online || db.online !== online) {
+			const data: Partial<network_members> = { online };
+			if (online) {
+				data.lastSeen = new Date();
+				if (member.physicalAddress) data.physicalAddress = member.physicalAddress;
+			}
+			statusWrites.push(
+				prisma.network_members.updateMany({ where: { nwid, id: db.id }, data }),
+			);
+		}
+		return member;
+	});
+
+	await Promise.all(statusWrites);
+	return enriched;
+};
+
+/**
+ * attachLiveStatus
+ *
+ * Read-only enrichment: given DB member rows, attaches live peers + connection
+ * status from a single controller `peers` call (no DB writes). Used by the
+ * paginated read path so it can serve a page from the DB while still reflecting
+ * up-to-the-moment online/Direct/Relayed status. Persisting that status is the
+ * job of the background reconcile.
+ */
+export const attachLiveStatus = async (
+	ctx: UserContext,
+	members: network_members[],
+): Promise<MemberEntity[]> => {
+	const controllerPeers = await ztController.peers(ctx).catch(() => []);
+	const peersByAddress = new Map<string, Peers>();
+	for (const peer of controllerPeers) {
+		peersByAddress.set(peer.address, peer as unknown as Peers);
+	}
+	return members.map((db) => {
+		const peers = peersByAddress.get(db.address || "") ?? ({} as Peers);
+		const activePreferredPath = findActivePreferredPeerPath(peers);
+		const member = {
+			...db,
+			peers,
+			physicalAddress: activePreferredPath?.address ?? db.physicalAddress,
+		} as unknown as MemberEntity;
+		member.conStatus = determineConnectionStatus(member);
+		return member;
+	});
+};
+
+// In-flight guard: keyed by network id, dedupes concurrent reconciles (the 10s
+// poll, several open tabs, or getNetworkById + getNetworkMembers on the same
+// page load) so they share a single controller sync instead of stacking.
+const inFlightReconciles = new Map<string, Promise<MemberEntity[]>>();
+
+/**
+ * Reconcile a network's members, but only ONE reconcile per network runs at a
+ * time — concurrent callers share the in-flight promise. Awaitable; used by the
+ * cold-start (empty cache) read paths that must block until populated.
+ */
+export const reconcileNetworkMembersOnce = (
+	ctx: UserContext,
+	nwid: string,
+	options: { full?: boolean } = {},
+): Promise<MemberEntity[]> => {
+	const existing = inFlightReconciles.get(nwid);
+	if (existing) return existing;
+	const run = reconcileNetworkMembers(ctx, nwid, options).finally(() => {
+		inFlightReconciles.delete(nwid);
+	});
+	inFlightReconciles.set(nwid, run);
+	return run;
+};
+
+/**
+ * Fire-and-forget reconcile (deduped via reconcileNetworkMembersOnce). Returns
+ * immediately; never throws into the caller. Used by warm read paths.
+ */
+export const triggerBackgroundReconcile = (
+	ctx: UserContext,
+	nwid: string,
+	options: { full?: boolean } = {},
+): void => {
+	void reconcileNetworkMembersOnce(ctx, nwid, options).catch((err) => {
+		console.error(`Background reconcile failed for network ${nwid}:`, err);
+	});
+};

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -16,9 +16,10 @@
  */
 import { type CreateNextContextOptions } from "@trpc/server/adapters/next";
 import type { Session } from "~/lib/authTypes";
-import { Socket as SocketIOServer } from "socket.io-client";
+import type { Server as SocketIOServer } from "socket.io";
 import { getServerAuthSession } from "~/lib/authSession";
 import { prisma } from "~/server/db";
+import { networkMembersChannel } from "~/utils/socketChannels";
 
 type CreateContextOptions = {
 	session: Session | null;
@@ -156,6 +157,28 @@ const enforceUserIsAdmin = t.middleware(async ({ ctx, next }) => {
 	return next();
 });
 /**
+ * After any successful mutation carrying a network id, push a live "changed"
+ * event to that network's Socket.IO room so every open tab refetches at once —
+ * without this, other tabs only catch up via the (browser-throttled, ~1/min in
+ * background) safety poll. Never fails the mutation if emitting throws.
+ */
+const emitNetworkChangeOnMutation = t.middleware(async ({ ctx, type, rawInput, next }) => {
+	const result = await next();
+	if (type === "mutation" && result.ok && ctx.wss) {
+		const input = rawInput as { nwid?: string; networkId?: string } | undefined;
+		const nwid = input?.nwid ?? input?.networkId;
+		if (nwid) {
+			try {
+				ctx.wss.to(networkMembersChannel(nwid)).emit(networkMembersChannel(nwid));
+			} catch {
+				// notification failure must never break the mutation
+			}
+		}
+	}
+	return result;
+});
+
+/**
  * Protected (authenticated) procedure
  *
  * If you want a query or mutation to ONLY be accessible to logged in users, use this. It verifies
@@ -163,7 +186,9 @@ const enforceUserIsAdmin = t.middleware(async ({ ctx, next }) => {
  *
  * @see https://trpc.io/docs/procedures
  */
-export const protectedProcedure = t.procedure.use(enforceUserIsAuthed);
+export const protectedProcedure = t.procedure
+	.use(enforceUserIsAuthed)
+	.use(emitNetworkChangeOnMutation);
 
 /**
  * Admin Role Protected (authenticated and ADMIN role) procedure

--- a/src/server/api/trpc.ts
+++ b/src/server/api/trpc.ts
@@ -162,21 +162,23 @@ const enforceUserIsAdmin = t.middleware(async ({ ctx, next }) => {
  * without this, other tabs only catch up via the (browser-throttled, ~1/min in
  * background) safety poll. Never fails the mutation if emitting throws.
  */
-const emitNetworkChangeOnMutation = t.middleware(async ({ ctx, type, rawInput, next }) => {
-	const result = await next();
-	if (type === "mutation" && result.ok && ctx.wss) {
-		const input = rawInput as { nwid?: string; networkId?: string } | undefined;
-		const nwid = input?.nwid ?? input?.networkId;
-		if (nwid) {
-			try {
-				ctx.wss.to(networkMembersChannel(nwid)).emit(networkMembersChannel(nwid));
-			} catch {
-				// notification failure must never break the mutation
+const emitNetworkChangeOnMutation = t.middleware(
+	async ({ ctx, type, rawInput, next }) => {
+		const result = await next();
+		if (type === "mutation" && result.ok && ctx.wss) {
+			const input = rawInput as { nwid?: string; networkId?: string } | undefined;
+			const nwid = input?.nwid ?? input?.networkId;
+			if (nwid) {
+				try {
+					ctx.wss.to(networkMembersChannel(nwid)).emit(networkMembersChannel(nwid));
+				} catch {
+					// notification failure must never break the mutation
+				}
 			}
 		}
-	}
-	return result;
-});
+		return result;
+	},
+);
 
 /**
  * Protected (authenticated) procedure

--- a/src/server/sync/syncManager.ts
+++ b/src/server/sync/syncManager.ts
@@ -1,0 +1,104 @@
+import type { Server as SocketIOServer } from "socket.io";
+import type { UserContext } from "~/types/ctx";
+import type { MemberEntity } from "~/types/local/member";
+import { reconcileNetworkMembersOnce } from "~/server/api/services/memberService";
+import { networkMembersChannel } from "~/utils/socketChannels";
+
+/**
+ * SyncManager
+ *
+ * Subscription-driven controller→DB reconcile worker. While at least one client
+ * is viewing a network (a Socket.IO subscriber), that network is reconciled on a
+ * ~10s cadence and a "changed" event is pushed to the room so the UI updates live
+ * — no client polling. When the last viewer leaves, the loop stops and the network
+ * falls back to the slow cron backstop.
+ *
+ * The loop is self-scheduling (each tick schedules the next only after it
+ * finishes), so a slow reconcile (e.g. 20s) can never overlap itself; combined
+ * with `reconcileNetworkMembersOnce`'s in-flight guard, a network is never synced
+ * twice concurrently.
+ */
+export const SYNC_INTERVAL_MS = 10_000;
+
+export const networkRoom = networkMembersChannel;
+
+const hashMembers = (members: MemberEntity[]): string =>
+	members
+		.map(
+			(m) =>
+				`${m.id}:${m.authorized ? 1 : 0}:${m.conStatus ?? ""}:${(
+					m.ipAssignments ?? []
+				).join(",")}:${m.name ?? ""}`,
+		)
+		.sort()
+		.join("|");
+
+interface NetworkSyncState {
+	refCount: number;
+	ctx: UserContext;
+	timer: ReturnType<typeof setTimeout> | null;
+	lastHash: string;
+}
+
+class SyncManager {
+	private io: SocketIOServer | null = null;
+	private networks = new Map<string, NetworkSyncState>();
+
+	/** Start (or ref-count) the live sync loop for a network. */
+	acquire(io: SocketIOServer, ctx: UserContext, nwid: string): void {
+		this.io = io;
+		const existing = this.networks.get(nwid);
+		if (existing) {
+			existing.refCount += 1;
+			return;
+		}
+		this.networks.set(nwid, { refCount: 1, ctx, timer: null, lastHash: "" });
+		void this.tick(nwid);
+	}
+
+	/** Drop a viewer; stop the loop when the last one leaves. */
+	release(nwid: string): void {
+		const state = this.networks.get(nwid);
+		if (!state) return;
+		state.refCount -= 1;
+		if (state.refCount <= 0) {
+			if (state.timer) clearTimeout(state.timer);
+			this.networks.delete(nwid);
+		}
+	}
+
+	private async tick(nwid: string): Promise<void> {
+		const state = this.networks.get(nwid);
+		if (!state) return;
+		state.timer = null;
+		const start = Date.now();
+		try {
+			const members = await reconcileNetworkMembersOnce(state.ctx, nwid);
+			const hash = hashMembers(members);
+			if (hash !== state.lastHash) {
+				state.lastHash = hash;
+				this.io?.to(networkRoom(nwid)).emit(networkRoom(nwid));
+			}
+		} catch (err) {
+			console.error(`SyncManager: reconcile failed for ${nwid}:`, err);
+		} finally {
+			// Reschedule only while still subscribed — never overlaps, since the
+			// next tick is queued only after this one completes.
+			const current = this.networks.get(nwid);
+			if (current && current.refCount > 0) {
+				const delay = Math.max(0, SYNC_INTERVAL_MS - (Date.now() - start));
+				current.timer = setTimeout(() => void this.tick(nwid), delay);
+			}
+		}
+	}
+
+	// --- test/introspection helpers ---
+	isSyncing(nwid: string): boolean {
+		return this.networks.has(nwid);
+	}
+	refCount(nwid: string): number {
+		return this.networks.get(nwid)?.refCount ?? 0;
+	}
+}
+
+export const syncManager = new SyncManager();

--- a/src/server/sync/syncManager.ts
+++ b/src/server/sync/syncManager.ts
@@ -50,6 +50,9 @@ class SyncManager {
 		const existing = this.networks.get(nwid);
 		if (existing) {
 			existing.refCount += 1;
+			// Track the most recent subscriber's context so the loop doesn't stay
+			// pinned to the first viewer's (possibly now-stale) session/credentials.
+			existing.ctx = ctx;
 			return;
 		}
 		this.networks.set(nwid, { refCount: 1, ctx, timer: null, lastHash: "" });

--- a/src/utils/socketChannels.ts
+++ b/src/utils/socketChannels.ts
@@ -1,0 +1,7 @@
+/**
+ * Socket.IO channel/room name for live updates of a network's members and
+ * options. Shared by the server (SyncManager emit, tRPC mutation push, the
+ * connection handler) and the client subscription hook so the name can't drift.
+ * Kept dependency-free so it is safe to import from client code.
+ */
+export const networkMembersChannel = (nwid: string) => `network-members:${nwid}`;


### PR DESCRIPTION
- Controller→DB reconcile keyed on member `revision` fetch only changed members, no per-load N+1, diff-skip writes.
- DB-first, server-side paginated member list; slimmed `getNetworkById` (counts, no full member array).
- Subscription-driven SyncManager worker (10s while a network page is open, 10-min cron otherwise) pushing live updates over Socket.IO, auth-required, room-scoped, no cross-network leakage. Mutations also push so all tabs update in ~1s.

Resolves #916