### PR TITLE
fix(networks): sort network list by member count

### DIFF
--- a/src/components/networkPage/networkTable.tsx
+++ b/src/components/networkPage/networkTable.tsx
@@ -72,6 +72,8 @@ export const NetworkTable = ({ tableData = [], onCreateNetwork }) => {
 		networkMembers: network_members[];
 		action: string;
 		memberCounts: {
+			authorized: number;
+			total: number;
 			display: string;
 		};
 	};
@@ -115,6 +117,16 @@ export const NetworkTable = ({ tableData = [], onCreateNetwork }) => {
 			}),
 			columnHelper.accessor("members", {
 				header: () => <span>{t("commonTable.header.memberActTot")}</span>,
+				// The accessor value is an array, so default sorting can't order it.
+				// Sort by the numeric member count (total, then authorized as tiebreaker).
+				sortingFn: (rowA, rowB) => {
+					const a = rowA.original.memberCounts;
+					const b = rowB.original.memberCounts;
+					return (
+						(a?.total ?? 0) - (b?.total ?? 0) ||
+						(a?.authorized ?? 0) - (b?.authorized ?? 0)
+					);
+				},
 				cell: ({ row: { original } }) => {
 					if (!Array.isArray(original.networkMembers)) {
 						return <NetworkTableMemberCount count="0" />;

--- a/src/components/organization/networkTable.tsx
+++ b/src/components/organization/networkTable.tsx
@@ -104,6 +104,16 @@ export const OrganizationNetworkTable = ({ tableData = [] }) => {
 			}),
 			columnHelper.accessor("memberCounts", {
 				header: () => <span>{t("commonTable.header.memberActTot")}</span>,
+				// The accessor value is an object, so default sorting can't order it.
+				// Sort by the numeric member count (total, then authorized as tiebreaker).
+				sortingFn: (rowA, rowB) => {
+					const a = rowA.original.memberCounts;
+					const b = rowB.original.memberCounts;
+					return (
+						(a?.total ?? 0) - (b?.total ?? 0) ||
+						(a?.authorized ?? 0) - (b?.authorized ?? 0)
+					);
+				},
 				cell: (info) => {
 					const data = info.getValue();
 					return <NetworkTableMemberCount count={data.display} />;


### PR DESCRIPTION
Sorting the "Members" column on the network list just shuffled rows instead of ordering them.
resolves #913 