### PR TITLE
fix: resolve CodeQL code-scanning alerts

### DIFF
--- a/.github/workflows/ci-tag.yml
+++ b/.github/workflows/ci-tag.yml
@@ -15,6 +15,9 @@ on:
         description: "Release version (e.g. v0.0.2)"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-build-runner.yml
+++ b/.github/workflows/docs-build-runner.yml
@@ -8,6 +8,9 @@ on:
       - "docs/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: [self-hosted, ztnet.network]

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -8,6 +8,9 @@ on:
   #     - "docs/**"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs-pull-request.yml
+++ b/.github/workflows/docs-pull-request.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     name: Build documentation

--- a/.github/workflows/install-ztnet.yml
+++ b/.github/workflows/install-ztnet.yml
@@ -12,6 +12,9 @@ on:
 env:
   LAST_UPDATED: ${{ github.event.head_commit.timestamp }}
   
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -15,6 +15,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   web_lint_test:
     name: Web - Lint - Format - Test

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,6 +5,9 @@ on:
     paths-ignore:
       - "docs/**"
 
+permissions:
+  contents: read
+
 jobs:
   web_lint_test_build:
     name: Web - Lint - Format - Test - Build

--- a/install.ztnet/src/routes/getBashInstaller.ts
+++ b/install.ztnet/src/routes/getBashInstaller.ts
@@ -21,6 +21,13 @@ export const getBashInstaller = async function (req: Request, res: Response) {
     },
   };
 
+  // Prevent path traversal via req.url: the resolved path must stay inside bash/.
+  const bashRoot = path.resolve(__dirname, '..', '..', 'bash');
+  if (!path.resolve(fileURL).startsWith(bashRoot + path.sep)) {
+    res.download(path.join(bashRoot, 'error.sh'), 'error.sh', options);
+    return;
+  }
+
   //validate that file exists
   fs.access(fileURL, fs.constants.R_OK, (err) => {
     if (err) {

--- a/install.ztnet/src/routes/getBinary.ts
+++ b/install.ztnet/src/routes/getBinary.ts
@@ -12,6 +12,12 @@ export const getBinary = async function (req: Request, res: Response) {
   if (!arch || !version || !app)
     return res.status(404).send('Need args: ?arch=armhf&app=ztnet&version="0.3.7"\n');
 
+  // Reject path traversal: each arg must be a single, separator-free path segment.
+  const isSafeSegment = (s: unknown): s is string =>
+    typeof s === 'string' && s.length > 0 && s !== '.' && s !== '..' && path.basename(s) === s;
+  if (!isSafeSegment(app) || !isSafeSegment(arch) || !isSafeSegment(version))
+    return res.status(400).send('Invalid arguments\n');
+
   const binPath = path.join(folderPath, app, arch);
 
   let filesArr: any = [];

--- a/install.ztnet/src/routes/postError.ts
+++ b/install.ztnet/src/routes/postError.ts
@@ -1,6 +1,15 @@
 import { Request, Response } from "express";
 import nodeMailer from "nodemailer";
 
+// Escape user-supplied content before embedding it in the HTML email body (XSS).
+const escapeHtml = (value: string): string =>
+	value
+		.replace(/&/g, "&amp;")
+		.replace(/</g, "&lt;")
+		.replace(/>/g, "&gt;")
+		.replace(/"/g, "&quot;")
+		.replace(/'/g, "&#39;");
+
 //fetch uavcast versions
 export const postError = function (req: Request, res: Response) {
 	const post_body = req.body;
@@ -38,7 +47,7 @@ export const postError = function (req: Request, res: Response) {
 		html: `
         <p>Something went wrong during the ztnet installation!</p><br>
         <b>Error message:</b><br>
-        <pre>${JSON.stringify(post_body, null, 2)}</pre>
+        <pre>${escapeHtml(JSON.stringify(post_body, null, 2))}</pre>
         `,
 	};
 	try {

--- a/src/pages/api/mkworld/config.ts
+++ b/src/pages/api/mkworld/config.ts
@@ -214,10 +214,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 											}
 										});
 
-									pass.pipe(fs.createWriteStream(path.join(mkworldDir, fileName)));
+									pass.pipe(
+										fs.createWriteStream(path.join(mkworldDir, path.basename(fileName))),
+									);
 								} else {
 									// Extract other files to the target directory
-									entry.pipe(fs.createWriteStream(path.join(mkworldDir, fileName)));
+									entry.pipe(
+										fs.createWriteStream(path.join(mkworldDir, path.basename(fileName))),
+									);
 								}
 							} else {
 								entry.autodrain();

--- a/src/pages/locale-redirect.tsx
+++ b/src/pages/locale-redirect.tsx
@@ -17,7 +17,9 @@ const LocaleRedirect = () => {
 		// Only accept internal, absolute paths to prevent open-redirect / XSS via the
 		// `target` param: reject protocol-relative ("//"), backslash tricks, and any
 		// URL with a scheme (e.g. "javascript:", "https:") — those don't start with "/".
-		const rawTarget = (query.target as string) || "/auth/register";
+		// `query.target` is `string | string[] | undefined`; the typeof check below
+		// narrows it to a real string (and rejects the array case).
+		const rawTarget = query.target;
 		const targetPath =
 			typeof rawTarget === "string" &&
 			rawTarget.startsWith("/") &&

--- a/src/pages/locale-redirect.tsx
+++ b/src/pages/locale-redirect.tsx
@@ -13,8 +13,18 @@ const LocaleRedirect = () => {
 		// Get all query parameters
 		const { query } = router;
 
-		// Get the target path from query parameter, default to '/auth/register'
-		const targetPath = (query.target as string) || "/auth/register";
+		// Get the target path from query parameter, default to '/auth/register'.
+		// Only accept internal, absolute paths to prevent open-redirect / XSS via the
+		// `target` param: reject protocol-relative ("//"), backslash tricks, and any
+		// URL with a scheme (e.g. "javascript:", "https:") — those don't start with "/".
+		const rawTarget = (query.target as string) || "/auth/register";
+		const targetPath =
+			typeof rawTarget === "string" &&
+			rawTarget.startsWith("/") &&
+			!rawTarget.startsWith("//") &&
+			!rawTarget.startsWith("/\\")
+				? rawTarget
+				: "/auth/register";
 
 		// Remove the target parameter from the query to avoid passing it along
 		const { target, ...restQuery } = query;


### PR DESCRIPTION
Fixes all open code-scanning alerts for the app.

**Code**
- `mkworld/config.ts`: wrap zip-entry names in `path.basename()`, fixes path-injection + zip-slip.
- `locale-redirect.tsx`: validate `target` is an internal path, fixes open-redirect + XSS.

**Workflows**
- Added least-privilege `permissions: { contents: read }` to all 7 workflows (Docker pushes use DockerHub secrets, not GITHUB_TOKEN; docs-build's deploy job keeps its pages/id-token write).