### PR TITLE
adaptive member-table refresh fallback

### DIFF
--- a/src/__tests__/pages/network/[id].test.tsx
+++ b/src/__tests__/pages/network/[id].test.tsx
@@ -70,6 +70,9 @@ jest.mock("next/router", () => ({
 jest.mock("~/hooks/useNetworkMembersSocket", () => ({
 	__esModule: true,
 	useNetworkMembersSocket: jest.fn(),
+	// Shared socket-state store: return "not connected" via the selector.
+	useNetworkSocketStore: (selector: (s: { connected: boolean }) => unknown) =>
+		selector({ connected: false }),
 	default: jest.fn(),
 }));
 describe("NetworkById component", () => {

--- a/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
+++ b/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
@@ -48,7 +48,11 @@ const SERVER_SORTABLE = new Set([
 export const NetworkMembersTable = ({ nwid, central = false, organizationId }: IProp) => {
 	const { query } = useRouter();
 	// Live updates: server pushes a "changed" event over Socket.IO and we refetch.
-	useNetworkMembersSocket(nwid, central);
+	// When the socket is connected we only need a slow safety poll; when it isn't
+	// (e.g. behind a proxy that doesn't forward WebSockets), poll faster so the
+	// table still stays reasonably fresh. Central has no socket → keep it slow.
+	const socketConnected = useNetworkMembersSocket(nwid, central);
+	const refetchInterval = central || socketConnected ? 60000 : 20000;
 	const [globalFilter, setGlobalFilter] = useState("");
 	const {
 		sorting,
@@ -110,7 +114,7 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 		},
 		// Socket.IO drives live updates; this slow poll is just a safety net for a
 		// dropped socket.
-		{ enabled: !!query.id, refetchInterval: 60000 },
+		{ enabled: !!query.id, refetchInterval },
 	);
 
 	const totalCount = membersData?.totalCount ?? 0;

--- a/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
+++ b/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
@@ -12,7 +12,10 @@ import { convertRGBtoRGBA } from "~/utils/randomColor";
 import { getLocalStorageItem } from "~/utils/localstorage";
 import TableFooter, { ALL_PAGE_SIZE } from "~/components/shared/tableFooter";
 import { type NetworkEntity } from "~/types/local/network";
-import { useNetworkMembersSocket } from "~/hooks/useNetworkMembersSocket";
+import {
+	useNetworkMembersSocket,
+	useNetworkSocketStore,
+} from "~/hooks/useNetworkMembersSocket";
 import { useMemberColumns } from "./useMemberColumns";
 import { useTablePersistence } from "./hooks/useTablePersistence";
 import { MembersToolbar } from "./components/MembersToolbar";
@@ -51,7 +54,8 @@ export const NetworkMembersTable = ({ nwid, central = false, organizationId }: I
 	// When the socket is connected we only need a slow safety poll; when it isn't
 	// (e.g. behind a proxy that doesn't forward WebSockets), poll faster so the
 	// table still stays reasonably fresh. Central has no socket → keep it slow.
-	const socketConnected = useNetworkMembersSocket(nwid, central);
+	useNetworkMembersSocket(nwid, central);
+	const socketConnected = useNetworkSocketStore((s) => s.connected);
 	const refetchInterval = central || socketConnected ? 60000 : 20000;
 	const [globalFilter, setGlobalFilter] = useState("");
 	const {

--- a/src/hooks/useNetworkMembersSocket.tsx
+++ b/src/hooks/useNetworkMembersSocket.tsx
@@ -1,26 +1,48 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
+import { create } from "zustand";
 import { io } from "socket.io-client";
 import { api } from "~/utils/api";
 import { networkMembersChannel } from "~/utils/socketChannels";
 
 /**
- * Subscribes to live member updates for a network over Socket.IO. While mounted,
- * the server reconciles this network every ~10s and pushes a "changed" event when
- * something actually changed; we then refetch the (DB-first) member list. On
- * unmount we unsubscribe so the server can stop the loop when no one is viewing.
+ * Shared connection state for the per-network live socket. One socket is opened
+ * (by the member table via useNetworkMembersSocket); the page and the table both
+ * read `connected` from here to drive an adaptive refetch fallback — slow while
+ * the socket is delivering live pushes, faster when it isn't (e.g. behind a proxy
+ * that doesn't forward WebSockets).
+ */
+interface NetworkSocketState {
+	connected: boolean;
+	setConnected: (connected: boolean) => void;
+}
+
+export const useNetworkSocketStore = create<NetworkSocketState>((set) => ({
+	connected: false,
+	setConnected: (connected) => set({ connected }),
+}));
+
+/**
+ * Opens a single Socket.IO connection for the given network, subscribes for live
+ * "changed" pushes, and invalidates the network + member queries when they
+ * arrive — so the WebSocket is the primary data path. Publishes live connection
+ * state to {@link useNetworkSocketStore} so consumers can fall back to polling
+ * only while the socket is down. Central networks have no local sync worker, so
+ * no socket is opened.
  *
  * Uses a dedicated (forceNew) socket so it never interferes with the org-chat
- * socket. Central networks are not handled by the local sync worker.
- *
- * Returns whether the live socket is currently connected, so the caller can fall
- * back to a faster safety poll only when live updates aren't flowing.
+ * socket. On unmount it unsubscribes so the server can stop the loop.
  */
-export const useNetworkMembersSocket = (nwid: string, central = false): boolean => {
+export const useNetworkMembersSocket = (nwid: string, central = false): void => {
 	const utils = api.useUtils();
-	const [isConnected, setIsConnected] = useState(false);
+	const setConnected = useNetworkSocketStore((s) => s.setConnected);
 
 	useEffect(() => {
-		if (!nwid || central) return;
+		// No live socket for central networks (or before the id is known): reflect
+		// "not connected" so consumers use the fallback poll.
+		if (!nwid || central) {
+			setConnected(false);
+			return;
+		}
 
 		let cancelled = false;
 		let socket: ReturnType<typeof io> | null = null;
@@ -33,16 +55,15 @@ export const useNetworkMembersSocket = (nwid: string, central = false): boolean 
 
 			socket = io({ forceNew: true });
 			const subscribe = () => socket?.emit("subscribe:network", { nwid });
-			// (re)subscribe on every (re)connect, and track connection state so the
-			// table can speed up its safety poll while the socket is down.
 			socket.on("connect", () => {
 				if (cancelled) return;
-				setIsConnected(true);
+				setConnected(true);
+				// (re)subscribe on every (re)connect.
 				subscribe();
 			});
 			socket.on("disconnect", () => {
 				if (cancelled) return;
-				setIsConnected(false);
+				setConnected(false);
 			});
 			socket.on(channel, () => {
 				void utils.network.getNetworkMembers.invalidate();
@@ -52,7 +73,7 @@ export const useNetworkMembersSocket = (nwid: string, central = false): boolean 
 
 		return () => {
 			cancelled = true;
-			setIsConnected(false);
+			setConnected(false);
 			if (socket) {
 				socket.emit("unsubscribe:network", { nwid });
 				socket.off(channel);
@@ -61,9 +82,7 @@ export const useNetworkMembersSocket = (nwid: string, central = false): boolean 
 				socket.disconnect();
 			}
 		};
-	}, [nwid, central, utils]);
-
-	return isConnected;
+	}, [nwid, central, utils, setConnected]);
 };
 
 export default useNetworkMembersSocket;

--- a/src/hooks/useNetworkMembersSocket.tsx
+++ b/src/hooks/useNetworkMembersSocket.tsx
@@ -36,10 +36,14 @@ export const useNetworkMembersSocket = (nwid: string, central = false): boolean 
 			// (re)subscribe on every (re)connect, and track connection state so the
 			// table can speed up its safety poll while the socket is down.
 			socket.on("connect", () => {
+				if (cancelled) return;
 				setIsConnected(true);
 				subscribe();
 			});
-			socket.on("disconnect", () => setIsConnected(false));
+			socket.on("disconnect", () => {
+				if (cancelled) return;
+				setIsConnected(false);
+			});
 			socket.on(channel, () => {
 				void utils.network.getNetworkMembers.invalidate();
 				void utils.network.getNetworkById.invalidate();
@@ -52,6 +56,8 @@ export const useNetworkMembersSocket = (nwid: string, central = false): boolean 
 			if (socket) {
 				socket.emit("unsubscribe:network", { nwid });
 				socket.off(channel);
+				socket.off("connect");
+				socket.off("disconnect");
 				socket.disconnect();
 			}
 		};

--- a/src/hooks/useNetworkMembersSocket.tsx
+++ b/src/hooks/useNetworkMembersSocket.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { io } from "socket.io-client";
 import { api } from "~/utils/api";
 import { networkMembersChannel } from "~/utils/socketChannels";
@@ -11,9 +11,13 @@ import { networkMembersChannel } from "~/utils/socketChannels";
  *
  * Uses a dedicated (forceNew) socket so it never interferes with the org-chat
  * socket. Central networks are not handled by the local sync worker.
+ *
+ * Returns whether the live socket is currently connected, so the caller can fall
+ * back to a faster safety poll only when live updates aren't flowing.
  */
-export const useNetworkMembersSocket = (nwid: string, central = false) => {
+export const useNetworkMembersSocket = (nwid: string, central = false): boolean => {
 	const utils = api.useUtils();
+	const [isConnected, setIsConnected] = useState(false);
 
 	useEffect(() => {
 		if (!nwid || central) return;
@@ -29,8 +33,13 @@ export const useNetworkMembersSocket = (nwid: string, central = false) => {
 
 			socket = io({ forceNew: true });
 			const subscribe = () => socket?.emit("subscribe:network", { nwid });
-			// (re)subscribe on every (re)connect.
-			socket.on("connect", subscribe);
+			// (re)subscribe on every (re)connect, and track connection state so the
+			// table can speed up its safety poll while the socket is down.
+			socket.on("connect", () => {
+				setIsConnected(true);
+				subscribe();
+			});
+			socket.on("disconnect", () => setIsConnected(false));
 			socket.on(channel, () => {
 				void utils.network.getNetworkMembers.invalidate();
 				void utils.network.getNetworkById.invalidate();
@@ -39,6 +48,7 @@ export const useNetworkMembersSocket = (nwid: string, central = false) => {
 
 		return () => {
 			cancelled = true;
+			setIsConnected(false);
 			if (socket) {
 				socket.emit("unsubscribe:network", { nwid });
 				socket.off(channel);
@@ -46,6 +56,8 @@ export const useNetworkMembersSocket = (nwid: string, central = false) => {
 			}
 		};
 	}, [nwid, central, utils]);
+
+	return isConnected;
 };
 
 export default useNetworkMembersSocket;

--- a/src/pages/network/[id].tsx
+++ b/src/pages/network/[id].tsx
@@ -3,6 +3,7 @@ import { useState, type ReactElement } from "react";
 import { LayoutAuthenticated } from "~/components/layouts/layout";
 import { NetworkRoutes } from "~/components/networkByIdPage/networkRoutes/networkRoutes";
 import { NetworkMembersTable } from "~/components/networkByIdPage/table/members/NetworkMembersTable";
+import { useNetworkSocketStore } from "~/hooks/useNetworkMembersSocket";
 import { api } from "~/utils/api";
 import { NetworkIpAssignment } from "~/components/networkByIdPage/networkIpAssignments";
 import { NetworkPrivatePublic } from "~/components/networkByIdPage/networkPrivatePublic";
@@ -57,6 +58,9 @@ const NetworkById = ({ orgIds }: IProps) => {
 	const { query, push: router } = useRouter();
 
 	const { data: globalOptions } = api.settings.getAllOptions.useQuery();
+	// Live socket state (published by the member table's socket) drives the
+	// fallback poll rate below.
+	const socketConnected = useNetworkSocketStore((s) => s.connected);
 
 	const { mutate: deleteNetwork } = api.network.deleteNetwork.useMutation();
 	const {
@@ -68,7 +72,9 @@ const NetworkById = ({ orgIds }: IProps) => {
 			nwid: query.id as string,
 			central: false,
 		},
-		{ enabled: !!query.id, refetchInterval: 10000 },
+		// The WebSocket is the primary update path (it invalidates this query on
+		// change); poll only as a fallback — slow while connected, faster when not.
+		{ enabled: !!query.id, refetchInterval: socketConnected ? 60000 : 20000 },
 	);
 	const { network, memberCount = 0 } = networkById || {};
 	const pageTitle = `${globalOptions?.siteName} - ${network?.name}`;

--- a/src/pages/organization/[orgid]/[id].tsx
+++ b/src/pages/organization/[orgid]/[id].tsx
@@ -3,6 +3,7 @@ import { useState, type ReactElement } from "react";
 import { LayoutOrganizationAuthenticated } from "~/components/layouts/layout";
 import { NetworkRoutes } from "~/components/networkByIdPage/networkRoutes/networkRoutes";
 import { NetworkMembersTable } from "~/components/networkByIdPage/table/members/NetworkMembersTable";
+import { useNetworkSocketStore } from "~/hooks/useNetworkMembersSocket";
 import { api } from "~/utils/api";
 import { NetworkIpAssignment } from "~/components/networkByIdPage/networkIpAssignments";
 import { NetworkPrivatePublic } from "~/components/networkByIdPage/networkPrivatePublic";
@@ -47,6 +48,7 @@ const OrganizationNetworkById = ({ orgIds }: IProps) => {
 	useOrganizationWebsocket(orgIds);
 
 	const { data: globalOptions } = api.settings.getAllOptions.useQuery();
+	const socketConnected = useNetworkSocketStore((s) => s.connected);
 	const { mutate: deleteNetwork } = api.network.deleteNetwork.useMutation();
 	const {
 		data: networkById,
@@ -56,7 +58,9 @@ const OrganizationNetworkById = ({ orgIds }: IProps) => {
 		{
 			nwid: query.id as string,
 		},
-		{ enabled: !!query.id, refetchInterval: 10000 },
+		// WebSocket is the primary update path; poll only as a fallback — slow while
+		// connected, faster when not.
+		{ enabled: !!query.id, refetchInterval: socketConnected ? 60000 : 20000 },
 	);
 	const { network, memberCount = 0 } = networkById || {};
 	const pageTitle = `${globalOptions?.siteName} - ${network?.name}`;


### PR DESCRIPTION
The member table's 60s safety poll runs even when live WebSocket updates are already flowing, and is too slow for setups where the socket can't connect.

Make the fallback adaptive: `useNetworkMembersSocket` now reports its connection state, and the table polls every 20s only when the socket is down, keeping the 60s poll when it's connected (and for central networks, which have no socket).