### PR TITLE
fix(auth): don't fail registration on notification email error

### DIFF
--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -299,21 +299,27 @@ export const authRouter = createTRPCRouter({
 			});
 
 			if (globalOptions?.userRegistrationNotification) {
-				const adminUsers = await ctx.prisma.user.findMany({
-					where: {
-						role: "ADMIN",
-					},
-				});
-
-				for (const adminUser of adminUsers) {
-					await sendMailWithTemplate(MailTemplateKey.Notification, {
-						to: adminUser.email,
-						userId: adminUser.id,
-						templateData: {
-							toName: adminUser.name,
-							notificationMessage: `A new user with the name ${name} and email ${email} has just registered!`,
+				// A failed admin-notification email (e.g. misconfigured SMTP or a
+				// secret mismatch) must never break the user's registration.
+				try {
+					const adminUsers = await ctx.prisma.user.findMany({
+						where: {
+							role: "ADMIN",
 						},
 					});
+
+					for (const adminUser of adminUsers) {
+						await sendMailWithTemplate(MailTemplateKey.Notification, {
+							to: adminUser.email,
+							userId: adminUser.id,
+							templateData: {
+								toName: adminUser.name,
+								notificationMessage: `A new user with the name ${name} and email ${email} has just registered!`,
+							},
+						});
+					}
+				} catch (e) {
+					console.error("Failed to send new-user registration notification:", e);
 				}
 			}
 			// add log if hasValidOrganizationToken is true

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -300,7 +300,8 @@ export const authRouter = createTRPCRouter({
 
 			if (globalOptions?.userRegistrationNotification) {
 				// A failed admin-notification email (e.g. misconfigured SMTP or a
-				// secret mismatch) must never break the user's registration.
+				// secret mismatch) must never break the user's registration. Isolate
+				// each recipient so one failure doesn't skip the other admins.
 				try {
 					const adminUsers = await ctx.prisma.user.findMany({
 						where: {
@@ -309,17 +310,24 @@ export const authRouter = createTRPCRouter({
 					});
 
 					for (const adminUser of adminUsers) {
-						await sendMailWithTemplate(MailTemplateKey.Notification, {
-							to: adminUser.email,
-							userId: adminUser.id,
-							templateData: {
-								toName: adminUser.name,
-								notificationMessage: `A new user with the name ${name} and email ${email} has just registered!`,
-							},
-						});
+						try {
+							await sendMailWithTemplate(MailTemplateKey.Notification, {
+								to: adminUser.email,
+								userId: adminUser.id,
+								templateData: {
+									toName: adminUser.name,
+									notificationMessage: `A new user with the name ${name} and email ${email} has just registered!`,
+								},
+							});
+						} catch (e) {
+							console.error(
+								`Failed to send registration notification to admin ${adminUser.email}:`,
+								e,
+							);
+						}
 					}
 				} catch (e) {
-					console.error("Failed to send new-user registration notification:", e);
+					console.error("Failed to load admins for registration notification:", e);
 				}
 			}
 			// add log if hasValidOrganizationToken is true


### PR DESCRIPTION
The "new user registered" admin email was awaited and unguarded, so a mail failure (bad SMTP config / secret mismatch) threw out of the register mutation and broke sign-up. Wrapped it in try/catch, it now logs and continues.