### PR TITLE
fix(routes): prevent duplicate managed routes and stale UI after edits

### DIFF
--- a/prisma/migrations/20260629000000_routes_unique_constraint/migration.sql
+++ b/prisma/migrations/20260629000000_routes_unique_constraint/migration.sql
@@ -1,0 +1,22 @@
+-- De-duplicate existing rows in "Routes" before adding the unique constraint.
+-- Keep the lowest id per (networkId, target, via) group. NULL `via` values are
+-- grouped together by PARTITION BY (window functions treat NULLs as one group),
+-- so duplicate LAN routes (via = NULL) are collapsed as well.
+DELETE FROM "Routes" r
+USING (
+  SELECT "id"
+  FROM (
+    SELECT
+      "id",
+      ROW_NUMBER() OVER (
+        PARTITION BY "networkId", "target", "via"
+        ORDER BY "id"
+      ) AS rn
+    FROM "Routes"
+  ) ranked
+  WHERE ranked.rn > 1
+) dupes
+WHERE r."id" = dupes."id";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Routes_networkId_target_via_key" ON "Routes"("networkId", "target", "via");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,8 @@ model Routes {
   networkId String
   notes     String?
   network   network @relation(fields: [networkId], references: [nwid], onDelete: Cascade)
+
+  @@unique([networkId, target, via])
 }
 
 model Notation {

--- a/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
+++ b/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
@@ -115,7 +115,9 @@ export const NetworkRoutesTable = React.memo(
 		const deleteRoute = useCallback(
 			(route: RoutesEntity) => {
 				const _routes = [...((network?.routes as RoutesEntity[]) || [])];
-				const newRouteArr = _routes.filter((r) => r.target !== route.target);
+				const newRouteArr = _routes.filter(
+					(r) => !(r.target === route.target && (r.via ?? null) === (route.via ?? null)),
+				);
 
 				updateManageRoutes({
 					updateParams: { routes: [...newRouteArr] },

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -224,16 +224,27 @@ export const networkRouter = createTRPCRouter({
 				const ztRouteKeys = new Set(
 					controllerNetwork.routes?.map((r) => `${r.target}|${r.via || "null"}`) || [],
 				);
+				// A smaller key-set than the raw row count means duplicate rows exist in
+				// the DB; those must be reconciled away even if the deduped sets match.
+				const dbHasDuplicateRoutes =
+					(networkFromDatabase.routes?.length || 0) !== dbRouteKeys.size;
 				const routesAreDifferent =
+					dbHasDuplicateRoutes ||
 					dbRouteKeys.size !== ztRouteKeys.size ||
 					![...dbRouteKeys].every((key) => ztRouteKeys.has(key));
 
 				if (routesAreDifferent) {
-					await syncNetworkRoutes({
+					const syncedNetwork = await syncNetworkRoutes({
 						networkId: input.nwid,
 						networkFromDatabase,
 						ztControllerRoutes: controllerNetwork.routes,
 					});
+					// Reflect the synced routes in the response so the UI is correct on
+					// this same request instead of only after a manual refresh.
+					if (syncedNetwork?.routes) {
+						networkFromDatabase.routes =
+							syncedNetwork.routes as typeof networkFromDatabase.routes;
+					}
 				}
 
 				// check if there is other network using same routes and return a notification

--- a/src/server/api/services/routesService.ts
+++ b/src/server/api/services/routesService.ts
@@ -45,6 +45,19 @@ export const syncNetworkRoutes = async ({
 		const routesToUpdate: RoutesEntity[] = [];
 		const routesToDelete: string[] = [];
 
+		// Self-heal: collapse duplicate DB rows that share the same logical key.
+		// The controller never holds duplicates, so any extra DB row with a key we
+		// already kept is stale and must be deleted (keep the first occurrence).
+		const seenKeys = new Set<string>();
+		for (const route of dbRoutes) {
+			const key = getRouteKey(route);
+			if (seenKeys.has(key)) {
+				if (route.id) routesToDelete.push(route.id);
+			} else {
+				seenKeys.add(key);
+			}
+		}
+
 		// Find routes to create or update
 		for (const [key, ztRoute] of newRouteMap) {
 			const existingRoute = existingRouteMap.get(key);
@@ -92,6 +105,7 @@ export const syncNetworkRoutes = async ({
 						target: route.target,
 						via: route.via || null,
 					})),
+					skipDuplicates: true,
 				});
 			}
 


### PR DESCRIPTION
## Summary

Fixes #944 — managed routes could be **duplicated** in the database (same `target` + `via`, different `id`). Once duplicated, the list showed the route twice, deleting one removed **both**, and the UI only became correct after a manual refresh.

## Root cause

Routes live in the ZeroTier controller (source of truth) and are mirrored into the `Routes` table by `syncNetworkRoutes` inside `getNetworkById`. Several issues combined:

- **No uniqueness** on `Routes`, so identical rows can coexist.
- **Concurrent sync inserts duplicates.** `managedRoutes` only updates the controller; the DB is mirrored on the next `getNetworkById`. The frontend fires `getNetworkById` concurrently (two components, each with `invalidate` *and* `refetch`), so two syncs both see "in controller, missing in DB" and each `createMany(...)` the same route.
- **Duplicates never self-heal.** The "needs sync?" check dedups DB rows into a `Set`, so "DB 2 rows / controller 1" looks equal and is never reconciled.
- **Delete matched by `target` only** (`deleteRoute`), so two same-`target` rows were both dropped.
- **Stale response.** The response was built from the pre-sync `networkFromDatabase` snapshot (the sync's return value was discarded), so fixes only appeared after a refresh.

## Changes

- **`prisma/schema.prisma`**: add `@@unique([networkId, target, via])` to `model Routes`.
- **migration `20260629000000_routes_unique_constraint`**: de-dup existing rows (keep lowest `id` per group, NULL `via` grouped together), then create the unique index.
- **`syncNetworkRoutes`**: `createMany({ skipDuplicates: true })` + self-heal (delete extra rows sharing a `target|via` key); its return value is now consumed.
- **`getNetworkById`**: detect duplicate DB rows to force a sync, and build the response from the **post-sync** routes.
- **`deleteRoute`** (client): match by `target` **and** `via`.

These are mutually reinforcing: even if a concurrent insert still races, the unique constraint + self-healing sync converge immediately, and the UI is correct on the same request.

## Testing

Verified in Docker (`docker compose up -d --build`):

- Migration applied cleanly: `Applying migration 20260629000000_routes_unique_constraint` → `All migrations have been successfully applied`.
- A network that had a duplicated route (`192.168.10.0/24 via 10.121.15.102`) collapsed from 3 → 2 rows.
- Cross-network check for duplicate `(networkId, target, via)` groups: **0** remaining.
- Unique index `Routes_networkId_target_via_key` present.
- App boots (`✓ Ready`), routes page serves and behaves correctly (add shows one row; delete removes only the targeted route without needing a refresh).

## Notes

`via` is nullable; Postgres treats NULLs as distinct in a plain unique index, so the self-heal step in `syncNetworkRoutes` is what guarantees convergence for LAN routes (`via = NULL`). The migration's de-dup groups NULLs together via `PARTITION BY` so existing NULL duplicates are also collapsed.
