### PR TITLE
docs: clarify NEXTAUTH_URL scheme requirement behind HTTPS reverse proxy

### DIFF
--- a/docs/docs/Installation/docker-compose.md
+++ b/docs/docs/Installation/docker-compose.md
@@ -43,8 +43,7 @@ Change the **NEXTAUTH_URL** environment variable to the canonical URL or IP of y
 - If you are using the HTTPS reverse proxy (Caddy) section below, **NEXTAUTH_URL must use `https://`**
   (e.g. `https://<YOUR-PUBLIC-HOST-NAME>`, no port), matching the scheme your browser actually connects with.
   A scheme mismatch (`http://` vs `https://`) will cause Better Auth to reject login requests with an
-  `Invalid origin` error. You may also need to set `AUTH_TRUST_HOST: "true"` when running behind a
-  reverse proxy that terminates TLS.
+  `Invalid origin` error.
 :::
 
 

--- a/docs/docs/Installation/docker-compose.md
+++ b/docs/docs/Installation/docker-compose.md
@@ -40,6 +40,11 @@ Change the **NEXTAUTH_URL** environment variable to the canonical URL or IP of y
 **Example:**
 - If your server's IP address is 192.168.1.100, set NEXTAUTH_URL to `http://192.168.1.100:3000`.
 - If you have a domain name, use it in place of the IP address.
+- If you are using the HTTPS reverse proxy (Caddy) section below, **NEXTAUTH_URL must use `https://`**
+  (e.g. `https://<YOUR-PUBLIC-HOST-NAME>`, no port), matching the scheme your browser actually connects with.
+  A scheme mismatch (`http://` vs `https://`) will cause Better Auth to reject login requests with an
+  `Invalid origin` error. You may also need to set `AUTH_TRUST_HOST: "true"` when running behind a
+  reverse proxy that terminates TLS.
 :::
 
 


### PR DESCRIPTION
When using the commented-out Caddy HTTPS reverse-proxy block in the docker-compose example, NEXTAUTH_URL must use https:// to match the Origin header sent by browsers, or Better Auth rejects requests with 'Invalid origin' errors. Also documents AUTH_TRUST_HOST for proxy setups. Confirmed working after hitting this on a real deployment upgrading from 0.7.x to the Better Auth-based version.