### PR TITLE
fix(routes): prevent duplicate managed routes

### DIFF
--- a/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
+++ b/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
@@ -115,7 +115,11 @@ export const NetworkRoutesTable = React.memo(
 		const deleteRoute = useCallback(
 			(route: RoutesEntity) => {
 				const _routes = [...((network?.routes as RoutesEntity[]) || [])];
-				const newRouteArr = _routes.filter((r) => r.target !== route.target);
+				// Match on target AND via so deleting one route doesn't drop another
+				// route that shares the same target (e.g. same target, different via).
+				const newRouteArr = _routes.filter(
+					(r) => !(r.target === route.target && (r.via ?? null) === (route.via ?? null)),
+				);
 
 				updateManageRoutes({
 					updateParams: { routes: [...newRouteArr] },

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -228,12 +228,24 @@ export const networkRouter = createTRPCRouter({
 					dbRouteKeys.size !== ztRouteKeys.size ||
 					![...dbRouteKeys].every((key) => ztRouteKeys.has(key));
 
-				if (routesAreDifferent) {
-					await syncNetworkRoutes({
+				// A raw row count higher than the deduped key-set means duplicate rows
+				// exist in the DB; those must be reconciled away even when the deduped
+				// sets match — otherwise duplicates would never self-heal.
+				const dbHasDuplicateRoutes =
+					(networkFromDatabase.routes?.length || 0) !== dbRouteKeys.size;
+
+				if (routesAreDifferent || dbHasDuplicateRoutes) {
+					const syncedNetwork = await syncNetworkRoutes({
 						networkId: input.nwid,
 						networkFromDatabase,
 						ztControllerRoutes: controllerNetwork.routes,
 					});
+					// Reflect the synced (deduped) routes in the response so the UI is
+					// correct on this same request instead of only after a refresh.
+					if (syncedNetwork?.routes) {
+						networkFromDatabase.routes =
+							syncedNetwork.routes as typeof networkFromDatabase.routes;
+					}
 				}
 
 				// check if there is other network using same routes and return a notification

--- a/src/server/api/services/routesService.ts
+++ b/src/server/api/services/routesService.ts
@@ -15,11 +15,18 @@ export const syncNetworkRoutes = async ({
 	ztControllerRoutes,
 }: SyncRoutesParams) => {
 	try {
-		const dbRoutes = networkFromDatabase?.routes;
+		const dbRoutesRaw = networkFromDatabase?.routes;
 
-		if (!dbRoutes || Array.isArray(dbRoutes) === false) {
+		if (!dbRoutesRaw || Array.isArray(dbRoutesRaw) === false) {
 			return networkFromDatabase;
 		}
+
+		// Order rows that carry a user note first, so the keep-first de-duplication
+		// below preserves notes (and stays consistent with the first-match lookup in
+		// existingRouteMap).
+		const dbRoutes = [...dbRoutesRaw].sort(
+			(a, b) => Number(!!b.notes?.trim()) - Number(!!a.notes?.trim()),
+		);
 
 		// Create Sets for deduplication
 		const dbRouteKeys = new Set(dbRoutes.map(getRouteKey));
@@ -44,6 +51,20 @@ export const syncNetworkRoutes = async ({
 		const routesToCreate: RoutesEntity[] = [];
 		const routesToUpdate: RoutesEntity[] = [];
 		const routesToDelete: string[] = [];
+
+		// Self-heal: collapse duplicate DB rows that share the same key (target|via).
+		// The controller is the source of truth and never holds duplicates, so any
+		// extra DB row is stale and must be deleted. dbRoutes is ordered note-first
+		// above, so keeping the first occurrence per key preserves any user note.
+		const seenKeys = new Set<string>();
+		for (const route of dbRoutes) {
+			const key = getRouteKey(route);
+			if (seenKeys.has(key)) {
+				if (route.id) routesToDelete.push(route.id);
+			} else {
+				seenKeys.add(key);
+			}
+		}
 
 		// Find routes to create or update
 		for (const [key, ztRoute] of newRouteMap) {


### PR DESCRIPTION
Fixes #944 — managed routes could be duplicated in the DB, showing twice and
deleting both when removing one.