### PR TITLE
fix(auth): store emailVerified as Boolean for better-auth

### DIFF
--- a/prisma/migrations/20260711000000_email_verified_boolean/migration.sql
+++ b/prisma/migrations/20260711000000_email_verified_boolean/migration.sql
@@ -1,0 +1,17 @@
+-- Convert "User"."emailVerified" from next-auth's DateTime? to better-auth's
+-- Boolean. better-auth writes a boolean to this column (on OIDC sign-up and on
+-- account-link updates); the old timestamp column rejected it, breaking OIDC
+-- login for both new and existing users (#948).
+--
+-- Existing state is preserved: a user who had a verification timestamp becomes
+-- `true` (verified), a NULL becomes `false` (not verified). No data is lost.
+
+ALTER TABLE "User" ALTER COLUMN "emailVerified" DROP DEFAULT;
+
+ALTER TABLE "User"
+  ALTER COLUMN "emailVerified" TYPE BOOLEAN
+  USING ("emailVerified" IS NOT NULL);
+
+ALTER TABLE "User" ALTER COLUMN "emailVerified" SET DEFAULT false;
+
+ALTER TABLE "User" ALTER COLUMN "emailVerified" SET NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -252,7 +252,7 @@ model User {
   id                     String                 @id @default(cuid())
   name                   String
   email                  String                 @unique
-  emailVerified          DateTime?
+  emailVerified          Boolean                @default(false)
   lastLogin              DateTime
   lastseen               DateTime?
   online                 Boolean?               @default(false)

--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -784,7 +784,7 @@ export const authRouter = createTRPCRouter({
 						id: user.id,
 					},
 					data: {
-						emailVerified: new Date().toISOString(),
+						emailVerified: true,
 					},
 				});
 				return { message: "Email verified successfully!" };

--- a/src/server/api/services/authService.ts
+++ b/src/server/api/services/authService.ts
@@ -67,7 +67,7 @@ export const ValidateMailLink = async (validate: Ivalidate) => {
 				id,
 			},
 			data: {
-				emailVerified: new Date(),
+				emailVerified: true,
 			},
 		});
 	} catch (error) {


### PR DESCRIPTION
Fixes #948, OIDC login broke for new signups and existing users.
Better-auth writes a boolean to `emailVerified`, but the column was next-auth's `DateTime?`, so Prisma rejected it (`Expected DateTime, provided Boolean`).