### PR TITLE
fix(auth): account update crashes when no password fields sent

### DIFF
--- a/src/server/api/routers/authRouter.ts
+++ b/src/server/api/routers/authRouter.ts
@@ -409,12 +409,14 @@ export const authRouter = createTRPCRouter({
 					.optional(),
 				password: z.string().optional(),
 				newPassword: passwordSchema("New Password does not meet the requirements!")
-					.transform((val) => val.trim())
+					// passwordSchema is already optional; guard the trim so an omitted
+					// field (e.g. updating only the name) doesn't call .trim() on undefined.
+					.transform((val) => val?.trim())
 					.optional(),
 				repeatNewPassword: passwordSchema(
 					"Repeat NewPassword does not meet the requirements!",
 				)
-					.transform((val) => val.trim())
+					.transform((val) => val?.trim())
 					.optional(),
 				name: z.string().nonempty().max(40).optional(),
 			}),


### PR DESCRIPTION
Editing name/email on account settings threw `Cannot read properties of undefined (reading 'trim')`. `passwordSchema` is already optional, and Zod 4 runs the `.transform(v => v.trim())` on the omitted (undefined) field.