### PR TITLE
fix(routes): eliminate duplicate managed routes

### DIFF
--- a/prisma/migrations/20260711100000_routes_unique_constraint/migration.sql
+++ b/prisma/migrations/20260711100000_routes_unique_constraint/migration.sql
@@ -1,12 +1,45 @@
 -- Collapse existing duplicate managed routes, then enforce uniqueness on
--- (networkId, target, via).
---
--- De-dup is NOTE-PRESERVING: within each (networkId, target, via) group we keep
--- the row that carries a user note (notes are user data and must never be
--- silently dropped); only if none has a note do we fall back to the lowest id.
--- NULL `via` values are grouped together by the window function, so duplicate
--- LAN routes (via = NULL) are collapsed as well.
+-- (networkId, target, via) at the database layer.
 
+-- 1. Preserve notes: fold every distinct non-empty note in a duplicate group
+--    into the row we keep, so no note is ever lost — even if multiple duplicates
+--    were separately annotated. `via IS NOT DISTINCT FROM` groups NULL vias
+--    together (LAN routes).
+WITH ranked AS (
+  SELECT
+    id,
+    "networkId",
+    "target",
+    "via",
+    ROW_NUMBER() OVER (
+      PARTITION BY "networkId", "target", "via"
+      ORDER BY
+        (CASE WHEN "notes" IS NOT NULL AND btrim("notes") <> '' THEN 0 ELSE 1 END),
+        "id"
+    ) AS rn
+  FROM "Routes"
+),
+merged AS (
+  SELECT
+    keep.id AS keep_id,
+    string_agg(DISTINCT NULLIF(btrim(r."notes"), ''), E'\n') AS notes
+  FROM ranked keep
+  JOIN "Routes" r
+    ON r."networkId" = keep."networkId"
+   AND r."target" = keep."target"
+   AND r."via" IS NOT DISTINCT FROM keep."via"
+  WHERE keep.rn = 1
+  GROUP BY keep.id
+)
+UPDATE "Routes" x
+SET "notes" = merged.notes
+FROM merged
+WHERE x.id = merged.keep_id
+  AND merged.notes IS NOT NULL
+  AND merged.notes IS DISTINCT FROM x."notes";
+
+-- 2. Delete the duplicate rows, keeping the first of each group (the note-bearing
+--    row is ordered first, and its notes now carry the whole group's notes).
 DELETE FROM "Routes" r
 USING (
   SELECT id
@@ -25,9 +58,11 @@ USING (
 ) dupes
 WHERE r.id = dupes.id;
 
--- CreateIndex
--- Note: a plain unique index treats NULL `via` as distinct, so it does not by
--- itself prevent duplicate LAN routes. Those are prevented in application code
--- (serialized route sync + in-transaction re-read); this index is the hard
--- guarantee for routes that have a `via`.
+-- 3a. Uniqueness for routes that have a `via` (gateway routes). A plain unique
+--     index treats NULL as distinct, so it covers only non-NULL vias.
 CREATE UNIQUE INDEX "Routes_networkId_target_via_key" ON "Routes"("networkId", "target", "via");
+
+-- 3b. Uniqueness for LAN routes (`via IS NULL`), which the index above cannot
+--     cover. A partial unique index closes that gap at the DB layer.
+CREATE UNIQUE INDEX "Routes_networkId_target_lan_key" ON "Routes"("networkId", "target")
+  WHERE "via" IS NULL;

--- a/prisma/migrations/20260711100000_routes_unique_constraint/migration.sql
+++ b/prisma/migrations/20260711100000_routes_unique_constraint/migration.sql
@@ -1,0 +1,33 @@
+-- Collapse existing duplicate managed routes, then enforce uniqueness on
+-- (networkId, target, via).
+--
+-- De-dup is NOTE-PRESERVING: within each (networkId, target, via) group we keep
+-- the row that carries a user note (notes are user data and must never be
+-- silently dropped); only if none has a note do we fall back to the lowest id.
+-- NULL `via` values are grouped together by the window function, so duplicate
+-- LAN routes (via = NULL) are collapsed as well.
+
+DELETE FROM "Routes" r
+USING (
+  SELECT id
+  FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY "networkId", "target", "via"
+        ORDER BY
+          (CASE WHEN "notes" IS NOT NULL AND btrim("notes") <> '' THEN 0 ELSE 1 END),
+          "id"
+      ) AS rn
+    FROM "Routes"
+  ) ranked
+  WHERE ranked.rn > 1
+) dupes
+WHERE r.id = dupes.id;
+
+-- CreateIndex
+-- Note: a plain unique index treats NULL `via` as distinct, so it does not by
+-- itself prevent duplicate LAN routes. Those are prevented in application code
+-- (serialized route sync + in-transaction re-read); this index is the hard
+-- guarantee for routes that have a `via`.
+CREATE UNIQUE INDEX "Routes_networkId_target_via_key" ON "Routes"("networkId", "target", "via");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -134,6 +134,9 @@ model Routes {
   notes     String?
   network   network @relation(fields: [networkId], references: [nwid], onDelete: Cascade)
 
+  // Uniqueness for routes that have a `via`. LAN routes (via = NULL) are covered
+  // by a partial unique index ("Routes_networkId_target_lan_key") created in the
+  // migration — Prisma can't express partial indexes here, so it lives in SQL.
   @@unique([networkId, target, via])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -133,6 +133,8 @@ model Routes {
   networkId String
   notes     String?
   network   network @relation(fields: [networkId], references: [nwid], onDelete: Cascade)
+
+  @@unique([networkId, target, via])
 }
 
 model Notation {

--- a/src/server/api/routers/networkRouter.ts
+++ b/src/server/api/routers/networkRouter.ts
@@ -26,7 +26,7 @@ import { isValidCIDR, isValidDns, isValidIP } from "../utils/ipUtils";
 import { networkProvisioningFactory } from "../services/networkService";
 import { Address4, Address6 } from "ip-address";
 import { MailTemplateKey } from "~/utils/enums";
-import { syncNetworkRoutes } from "../services/routesService";
+import { syncNetworkRoutesOnce } from "../services/routesService";
 
 const RouteSchema = z.object({
 	target: z
@@ -235,7 +235,7 @@ export const networkRouter = createTRPCRouter({
 					(networkFromDatabase.routes?.length || 0) !== dbRouteKeys.size;
 
 				if (routesAreDifferent || dbHasDuplicateRoutes) {
-					const syncedNetwork = await syncNetworkRoutes({
+					const syncedNetwork = await syncNetworkRoutesOnce({
 						networkId: input.nwid,
 						networkFromDatabase,
 						ztControllerRoutes: controllerNetwork.routes,

--- a/src/server/api/services/routesService.ts
+++ b/src/server/api/services/routesService.ts
@@ -105,15 +105,32 @@ export const syncNetworkRoutes = async ({
 
 		// Perform all database operations in a transaction
 		const updatedNetwork = await prisma.$transaction(async (tx) => {
-			// Create new routes
+			// Create new routes. Re-read the current keys inside the transaction so a
+			// route inserted by a prior/concurrent sync (after our snapshot was taken)
+			// is never inserted twice; `skipDuplicates` is the hard backstop via the
+			// (networkId, target, via) unique index.
 			if (routesToCreate.length > 0) {
-				await tx.routes.createMany({
-					data: routesToCreate.map((route) => ({
-						networkId: networkId,
-						target: route.target,
-						via: route.via || null,
-					})),
-				});
+				const currentKeys = new Set(
+					(
+						await tx.routes.findMany({
+							where: { networkId },
+							select: { target: true, via: true },
+						})
+					).map(getRouteKey),
+				);
+				const freshRoutes = routesToCreate.filter(
+					(r) => !currentKeys.has(getRouteKey(r)),
+				);
+				if (freshRoutes.length > 0) {
+					await tx.routes.createMany({
+						data: freshRoutes.map((route) => ({
+							networkId: networkId,
+							target: route.target,
+							via: route.via || null,
+						})),
+						skipDuplicates: true,
+					});
+				}
 			}
 
 			// Update existing routes
@@ -151,6 +168,26 @@ export const syncNetworkRoutes = async ({
 	} catch (error) {
 		console.error("Error syncing network routes:", error);
 	}
+};
+
+// The frontend fires several getNetworkById calls at once (multiple components,
+// each invalidating + refetching), so route syncs for the same network can run
+// concurrently and each mirror the same controller route — the source of the
+// transient duplicate rows. Serialize them per network: concurrent callers share
+// a single in-flight sync instead of racing. Single-process, same pattern as the
+// member reconcile guard.
+const inFlightRouteSyncs = new Map<string, ReturnType<typeof syncNetworkRoutes>>();
+
+export const syncNetworkRoutesOnce = (
+	params: SyncRoutesParams,
+): ReturnType<typeof syncNetworkRoutes> => {
+	const existing = inFlightRouteSyncs.get(params.networkId);
+	if (existing) return existing;
+	const run = syncNetworkRoutes(params).finally(() => {
+		inFlightRouteSyncs.delete(params.networkId);
+	});
+	inFlightRouteSyncs.set(params.networkId, run);
+	return run;
 };
 
 // Helper function to generate a unique key for a route

--- a/src/server/api/services/routesService.ts
+++ b/src/server/api/services/routesService.ts
@@ -107,8 +107,9 @@ export const syncNetworkRoutes = async ({
 		const updatedNetwork = await prisma.$transaction(async (tx) => {
 			// Create new routes. Re-read the current keys inside the transaction so a
 			// route inserted by a prior/concurrent sync (after our snapshot was taken)
-			// is never inserted twice; `skipDuplicates` is the hard backstop via the
-			// (networkId, target, via) unique index.
+			// is never inserted twice. `skipDuplicates` is the hard DB backstop: a
+			// unique index covers routes that have a `via`, and a partial unique index
+			// covers LAN routes (via IS NULL) — together they cover every route.
 			if (routesToCreate.length > 0) {
 				const currentKeys = new Set(
 					(


### PR DESCRIPTION
Managed routes could be duplicated in the DB: shown twice, deleting one removed both, and duplicates only cleared after a manual refresh.

After testing a code-only approach, it turns out we need a DB migration to completely solve this, concurrent `getNetworkById` syncs could still create transient duplicates that a plain self-heal only cleaned up on the next refresh.