### PR TITLE
Node Name column blank on load + service worker precache error

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -2,12 +2,22 @@ const CACHE_NAME = 'my-nextjs-pwa-cache';
 const urlsToCache = [
   '/',
   '/manifest.json',
-  '/icon.png'
+  '/ztnet_300x300.png'
   // Add other static assets to cache
 ];
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(urlsToCache))
+    caches.open(CACHE_NAME).then((cache) =>
+      // Cache each asset individually so one missing/failed request doesn't
+      // reject the whole precache (which surfaces as an uncaught addAll error).
+      Promise.all(
+        urlsToCache.map((url) =>
+          cache.add(url).catch((err) => {
+            console.warn('SW precache skipped', url, err);
+          })
+        )
+      )
+    )
   );
 });
 self.addEventListener('fetch', (event) => {

--- a/src/components/networkByIdPage/networkRoutes/collumns.tsx
+++ b/src/components/networkByIdPage/networkRoutes/collumns.tsx
@@ -1,5 +1,4 @@
 import { createColumnHelper } from "@tanstack/react-table";
-import { MemberEntity } from "~/types/local/member";
 import { RoutesEntity } from "~/types/local/network";
 
 const columnHelper = createColumnHelper<RoutesEntity>();
@@ -7,7 +6,6 @@ const columnHelper = createColumnHelper<RoutesEntity>();
 export const networkRoutesColumns = (
 	deleteRoute: (route: RoutesEntity) => void,
 	isUpdating: boolean,
-	members: MemberEntity[],
 ) => [
 	columnHelper.accessor("id", {
 		cell: (info) => info.getValue(),
@@ -23,8 +21,12 @@ export const networkRoutesColumns = (
 		id: "nodeName",
 		header: "Node Name",
 		cell: (info) => {
+			// Read the member list live from table meta at render time, so the Node
+			// Name resolves as soon as the members query loads — without depending on
+			// the row model rebuilding (which only happens when the routes change).
+			const members = info.table.options.meta?.members ?? [];
 			// check if ipAssignments has the via ip and return the node name
-			const node = members?.find((member) =>
+			const node = members.find((member) =>
 				member.ipAssignments?.includes(info.row.original.via),
 			);
 			return node?.name || null;

--- a/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
+++ b/src/components/networkByIdPage/networkRoutes/networkRoutesTable.tsx
@@ -5,11 +5,13 @@ import {
 	flexRender,
 	type HeaderGroup,
 	type Row,
+	type RowData,
 	getSortedRowModel,
 	SortingState,
 } from "@tanstack/react-table";
 import { networkRoutesColumns } from "./collumns";
 import { RoutesEntity } from "~/types/local/network";
+import { MemberEntity } from "~/types/local/member";
 import { api } from "~/utils/api";
 import {
 	useTrpcApiErrorHandler,
@@ -17,6 +19,15 @@ import {
 } from "~/hooks/useTrpcApiHandler";
 import { useRouter } from "next/router";
 import { useEditableColumn } from "./routesEditCell";
+
+declare module "@tanstack/react-table" {
+	// biome-ignore lint/correctness/noUnusedVariables: module augmentation
+	interface TableMeta<TData extends RowData> {
+		// Live member list read by the Node Name cell at render time, so the column
+		// resolves as soon as the members query loads (no row-model rebuild needed).
+		members?: MemberEntity[];
+	}
+}
 
 interface IProp {
 	central?: boolean;
@@ -29,24 +40,33 @@ interface TableHeaderProps {
 
 interface TableBodyProps {
 	rows: Row<RoutesEntity>[];
+	// Not rendered directly — the Node Name cell reads the member list live from
+	// table `meta`. It's a prop purely so the memo below re-renders when members
+	// load/change; `rows` is memoized on the routes and stays stable across member
+	// refetches, which would otherwise leave Node Name blank until a route edit.
+	members: MemberEntity[];
 }
 
 // Memoized table body component
-const TableBody = React.memo<TableBodyProps>(({ rows }) => {
-	return (
-		<tbody>
-			{rows.map((row) => (
-				<tr key={row.id} className="hover:bg-gray-600/10">
-					{row.getVisibleCells().map((cell) => (
-						<td key={cell.id} className="px-4 text-sm">
-							{flexRender(cell.column.columnDef.cell, cell.getContext())}
-						</td>
-					))}
-				</tr>
-			))}
-		</tbody>
-	);
-});
+const TableBody = React.memo<TableBodyProps>(
+	({ rows }) => {
+		return (
+			<tbody>
+				{rows.map((row) => (
+					<tr key={row.id} className="hover:bg-gray-600/10">
+						{row.getVisibleCells().map((cell) => (
+							<td key={cell.id} className="px-4 text-sm">
+								{flexRender(cell.column.columnDef.cell, cell.getContext())}
+							</td>
+						))}
+					</tr>
+				))}
+			</tbody>
+		);
+	},
+	// Re-render on a new row set OR a changed member list (see `members` above).
+	(prev, next) => prev.rows === next.rows && prev.members === next.members,
+);
 
 TableBody.displayName = "TableBody";
 
@@ -138,13 +158,11 @@ export const NetworkRoutesTable = React.memo(
 		// Memoize the routes data
 		const data = useMemo(() => network?.routes ?? [], [network?.routes]);
 
-		// Memoize columns with a stable reference; rebuild only when its inputs
-		// change. Crucially this includes `members`, so the Node Name column
-		// re-resolves as soon as the member list loads — instead of staying blank
-		// until an unrelated route change forces the row model to recompute.
+		// Stable columns. The Node Name cell reads the member list live from table
+		// `meta` (below), so columns don't need to rebuild when members load.
 		const columns = useMemo(
-			() => networkRoutesColumns(deleteRoute, isUpdating, members),
-			[deleteRoute, isUpdating, members],
+			() => networkRoutesColumns(deleteRoute, isUpdating),
+			[deleteRoute, isUpdating],
 		);
 
 		const table = useReactTable({
@@ -154,6 +172,9 @@ export const NetworkRoutesTable = React.memo(
 			onSortingChange: setSorting,
 			getSortedRowModel: getSortedRowModel(),
 			getCoreRowModel: getCoreRowModel(),
+			// Live member list for the Node Name column; read by the cell at render
+			// time so it refreshes the moment the members query resolves.
+			meta: { members },
 			state: {
 				sorting,
 				columnVisibility: { id: false, nodeName: !central, notes: !central },
@@ -171,7 +192,7 @@ export const NetworkRoutesTable = React.memo(
 					className="table-auto w-full min-w-[600px] border-collapse"
 				>
 					<TableHeader headerGroups={headerGroups} />
-					<TableBody rows={rows} />
+					<TableBody rows={rows} members={members} />
 				</table>
 			</div>
 		);

--- a/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
+++ b/src/components/networkByIdPage/table/members/NetworkMembersTable.tsx
@@ -24,7 +24,7 @@ import { TABLE_MIN_WIDTH } from "./constants";
 declare module "@tanstack/react-table" {
 	// biome-ignore lint/correctness/noUnusedVariables: module augmentation
 	interface TableMeta<TData extends RowData> {
-		updateData: (rowIndex: number, columnId: string, value: unknown) => void;
+		updateData?: (rowIndex: number, columnId: string, value: unknown) => void;
 		// Live data read by cells at render time (so columns stay stable across
 		// refetches and cells avoid per-row query subscriptions).
 		network?: NetworkEntity;


### PR DESCRIPTION
Two small production fixes:

- **Routes table:** Node Name stayed blank until a route was edited. The cell now reads the member list live from table `meta`, and the memoized table body re-renders when members load, names populate on their own.
- **Service worker:** precached a non-existent `/icon.png`, causing an uncaught `addAll` error on every page. Fixed the path and made the precache tolerant of a single failed asset.