### PR TITLE
fix: OAuth user creation fails on missing User.updatedAt column

### DIFF
--- a/prisma/migrations/20260724000000_user_updated_at/migration.sql
+++ b/prisma/migrations/20260724000000_user_updated_at/migration.sql
@@ -1,0 +1,6 @@
+-- better-auth's user schema requires an `updatedAt` column, and its Prisma
+-- adapter sets it on every user create. The original better-auth migration
+-- added `updatedAt` to Account and Session but missed User, which broke user
+-- creation via the OAuth flow (e.g. Azure AD/Entra ID). Add it here, matching
+-- the sibling tables. Existing rows default to the current timestamp.
+ALTER TABLE "User" ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -282,6 +282,7 @@ model User {
   expiresAt              DateTime? // null means it never expires
   isActive               Boolean                @default(true)
   createdAt              DateTime               @default(now())
+  updatedAt              DateTime               @default(now()) @updatedAt
   userGroup              UserGroup?             @relation(fields: [userGroupId], references: [id], onDelete: Restrict)
   options                UserOptions?
   accounts               Account[]


### PR DESCRIPTION
better-auth sets `updatedAt` on every user create, but the User table was missing that column, breaking OAuth signup (Azure AD/Entra ID). Adds the column via migration, matching the Account/Session tables.

Resolves #958